### PR TITLE
Add lightweight Calendar view

### DIFF
--- a/main.js
+++ b/main.js
@@ -7307,6 +7307,7 @@ function renderDayChips(parent, day, options) {
       text: task.title,
       attr: { type: "button" }
     });
+    applyProjectColor(chip, task, options.projectColors);
     chip.addEventListener("click", (event) => {
       event.preventDefault();
       event.stopPropagation();
@@ -7341,6 +7342,7 @@ function renderSelectedDay(parent, selectedDate, entries, options) {
       cls: `belki-calendar-selected-task is-${entry.role}`,
       attr: { type: "button" }
     });
+    applyProjectColor(row, entry.task, options.projectColors);
     row.addEventListener("click", () => options.onOpenTask(entry.task));
     row.createSpan({
       cls: "belki-calendar-selected-role",
@@ -7348,11 +7350,27 @@ function renderSelectedDay(parent, selectedDate, entries, options) {
     });
     const content = row.createDiv({ cls: "belki-calendar-selected-content" });
     content.createDiv({ cls: "belki-calendar-selected-title", text: entry.task.title });
+    const project = normalizeTaskProject(entry.task.project);
     content.createDiv({
       cls: "belki-calendar-selected-meta",
-      text: entry.role === "deadline" && entry.task.due ? `Due ${formatDateLabel(entry.task.due)}` : entry.task.deadline && entry.task.deadline !== selectedDate ? `Deadline ${formatDateLabel(entry.task.deadline)}` : ""
+      text: [
+        project,
+        entry.role === "deadline" && entry.task.due ? `Due ${formatDateLabel(entry.task.due)}` : entry.task.deadline && entry.task.deadline !== selectedDate ? `Deadline ${formatDateLabel(entry.task.deadline)}` : ""
+      ].filter(Boolean).join(" \xB7 ")
     });
   }
+}
+function applyProjectColor(element, task, projectColors) {
+  const project = normalizeTaskProject(task.project);
+  if (!project) {
+    return;
+  }
+  const color = getProjectColor(project, projectColors);
+  element.addClass("belki-calendar-has-project-color");
+  element.setCssProps({
+    "--belki-calendar-project-bg": color.light,
+    "--belki-calendar-project-color": color.regular
+  });
 }
 function selectDay(day, options) {
   const month = day.isCurrentMonth ? options.month : calendarMonthFromIsoDate(day.date) || options.month;
@@ -8160,6 +8178,7 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
         month: this.calendarMonth,
         selectedDate: this.calendarSelectedDate,
         tasks: this.sortTasks(active.filter(hasCalendarDate)),
+        projectColors: this.settings.projectColors,
         sortTasks: (tasks) => this.sortTasks(tasks),
         onNavigate: (month, selectedDate) => {
           this.calendarMonth = month;

--- a/main.js
+++ b/main.js
@@ -98,6 +98,18 @@ function formatDueDateChip(value) {
     ...year !== thisYear ? { year: "numeric" } : {}
   }).format(date);
 }
+function formatDateLabel(value) {
+  if (!isIsoDate(value)) {
+    return value;
+  }
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  return new Intl.DateTimeFormat(void 0, {
+    weekday: "short",
+    month: "short",
+    day: "numeric"
+  }).format(date);
+}
 function isoDateToUtcDay(value) {
   if (!isIsoDate(value)) {
     return null;
@@ -7051,6 +7063,313 @@ function createTaskActionMenuButton(parent, label, onClick) {
   });
 }
 
+// src/views/calendar/calendarUtils.ts
+var CALENDAR_WEEK_START = 1;
+var CALENDAR_WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+function calendarMonthFromDate(date) {
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth()
+  };
+}
+function calendarMonthFromIsoDate(value) {
+  const date = parseIsoDateLocal(value);
+  return date ? calendarMonthFromDate(date) : null;
+}
+function addCalendarMonths(month, amount) {
+  return calendarMonthFromDate(new Date(month.year, month.month + amount, 1));
+}
+function selectedDateForCalendarMonth(month, preferredDate) {
+  const preferred = preferredDate ? parseIsoDateLocal(preferredDate) : null;
+  const preferredDay = (preferred == null ? void 0 : preferred.getDate()) || 1;
+  const day = Math.min(preferredDay, daysInCalendarMonth(month));
+  return toIsoDate(new Date(month.year, month.month, day));
+}
+function formatCalendarMonthLabel(month) {
+  return new Intl.DateTimeFormat(void 0, {
+    month: "long",
+    year: "numeric"
+  }).format(new Date(month.year, month.month, 1));
+}
+function parseIsoDateLocal(value) {
+  if (!isIsoDate(value)) {
+    return null;
+  }
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return null;
+  }
+  return date;
+}
+function isValidCalendarDate(value) {
+  return Boolean(parseIsoDateLocal(value));
+}
+function daysInCalendarMonth(month) {
+  return new Date(month.year, month.month + 1, 0).getDate();
+}
+
+// src/views/calendar/calendarModel.ts
+function buildCalendarTaskGroups(tasks) {
+  const dueTasksByDate = /* @__PURE__ */ new Map();
+  const deadlineTasksByDate = /* @__PURE__ */ new Map();
+  for (const task of tasks) {
+    if (isValidCalendarDate(task.due)) {
+      appendTask(dueTasksByDate, task.due, task);
+    }
+    if (isValidCalendarDate(task.deadline) && task.deadline !== task.due) {
+      appendTask(deadlineTasksByDate, task.deadline, task);
+    }
+  }
+  sortTaskGroups(dueTasksByDate);
+  sortTaskGroups(deadlineTasksByDate);
+  return {
+    dueTasksByDate,
+    deadlineTasksByDate
+  };
+}
+function buildMonthGrid(options) {
+  var _a;
+  const today = isValidCalendarDate(options.today) ? options.today : todayIso();
+  const selectedDate = isValidCalendarDate(options.selectedDate) ? options.selectedDate : void 0;
+  const weekStartsOn = (_a = options.weekStartsOn) != null ? _a : CALENDAR_WEEK_START;
+  const firstOfMonth = new Date(options.month.year, options.month.month, 1);
+  const leadingDayCount = (firstOfMonth.getDay() - weekStartsOn + 7) % 7;
+  const gridStart = new Date(options.month.year, options.month.month, 1 - leadingDayCount);
+  const days = [];
+  for (let index = 0; index < 42; index += 1) {
+    const date = new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + index);
+    const isoDate = toIsoDate(date);
+    const dueTasks = options.taskGroups.dueTasksByDate.get(isoDate) || [];
+    const deadlineTasks = options.taskGroups.deadlineTasksByDate.get(isoDate) || [];
+    days.push({
+      date: isoDate,
+      dayNumber: date.getDate(),
+      isCurrentMonth: date.getFullYear() === options.month.year && date.getMonth() === options.month.month,
+      isToday: isoDate === today,
+      isSelected: isoDate === selectedDate,
+      isOverdue: isoDate < today && dueTasks.some((task) => !task.completed),
+      dueTasks,
+      deadlineTasks,
+      deadlineCount: deadlineTasks.length,
+      totalCount: dueTasks.length + deadlineTasks.length
+    });
+  }
+  return days;
+}
+function getCalendarTasksForDate(taskGroups, date) {
+  const dueTasks = taskGroups.dueTasksByDate.get(date) || [];
+  const deadlineTasks = taskGroups.deadlineTasksByDate.get(date) || [];
+  const entries = dueTasks.map((task) => ({ task, role: "due" }));
+  const seenTaskIds = new Set(dueTasks.map((task) => task.id));
+  for (const task of deadlineTasks) {
+    if (!seenTaskIds.has(task.id)) {
+      entries.push({ task, role: "deadline" });
+    }
+  }
+  return entries;
+}
+function hasCalendarDate(task) {
+  return isValidCalendarDate(task.due) || isValidCalendarDate(task.deadline);
+}
+function appendTask(groups, date, task) {
+  const tasks = groups.get(date);
+  if (tasks) {
+    tasks.push(task);
+  } else {
+    groups.set(date, [task]);
+  }
+}
+function sortTaskGroups(groups) {
+  for (const [date, tasks] of groups) {
+    if (!parseIsoDateLocal(date)) {
+      groups.delete(date);
+      continue;
+    }
+    groups.set(date, [...tasks].sort((a, b) => a.order - b.order));
+  }
+}
+
+// src/views/calendar/CalendarView.ts
+var MAX_VISIBLE_CHIPS = 3;
+function renderCalendarView(options) {
+  const taskGroups = buildCalendarTaskGroups(options.tasks);
+  const today = todayIso();
+  const days = buildMonthGrid({
+    month: options.month,
+    taskGroups,
+    selectedDate: options.selectedDate,
+    today
+  });
+  const selectedEntries = sortEntries(
+    getCalendarTasksForDate(taskGroups, options.selectedDate),
+    options.sortTasks
+  );
+  const calendar = options.parent.createDiv({ cls: "belki-calendar" });
+  renderCalendarToolbar(calendar, options, today);
+  renderCalendarGrid(calendar, days, options);
+  renderSelectedDay(calendar, options.selectedDate, selectedEntries, options);
+}
+function renderCalendarToolbar(parent, options, today) {
+  const toolbar = parent.createDiv({ cls: "belki-calendar-toolbar" });
+  const previous = toolbar.createEl("button", {
+    cls: "belki-calendar-nav-button",
+    attr: { type: "button", "aria-label": "Previous month" }
+  });
+  createBelkiIcon(previous, "chevron-left");
+  previous.addEventListener("click", () => {
+    const month = addCalendarMonths(options.month, -1);
+    options.onNavigate(month, selectedDateForCalendarMonth(month, options.selectedDate));
+  });
+  toolbar.createDiv({
+    cls: "belki-calendar-month-label",
+    text: formatCalendarMonthLabel(options.month)
+  });
+  const next = toolbar.createEl("button", {
+    cls: "belki-calendar-nav-button",
+    attr: { type: "button", "aria-label": "Next month" }
+  });
+  createBelkiIcon(next, "chevron-right");
+  next.addEventListener("click", () => {
+    const month = addCalendarMonths(options.month, 1);
+    options.onNavigate(month, selectedDateForCalendarMonth(month, options.selectedDate));
+  });
+  toolbar.createEl("button", {
+    cls: "belki-calendar-today-button",
+    text: "Today",
+    attr: { type: "button" }
+  }).addEventListener("click", () => {
+    options.onNavigate(calendarMonthFromDate(/* @__PURE__ */ new Date()), today);
+  });
+}
+function renderCalendarGrid(parent, days, options) {
+  const grid = parent.createDiv({ cls: "belki-calendar-grid" });
+  for (const label of CALENDAR_WEEKDAY_LABELS) {
+    grid.createDiv({ cls: "belki-calendar-weekday", text: label });
+  }
+  for (const day of days) {
+    renderCalendarDay(grid, day, options);
+  }
+}
+function renderCalendarDay(parent, day, options) {
+  const classes = [
+    "belki-calendar-day",
+    day.isCurrentMonth ? void 0 : "is-muted",
+    day.isToday ? "is-today" : void 0,
+    day.isSelected ? "is-selected" : void 0,
+    day.isOverdue ? "is-overdue" : void 0,
+    day.totalCount > 0 ? "has-tasks" : void 0
+  ].filter(Boolean).join(" ");
+  const dayEl = parent.createEl("div", {
+    cls: classes,
+    attr: {
+      role: "button",
+      tabindex: "0",
+      "aria-label": `${formatDateLabel(day.date)}, ${day.totalCount} task${day.totalCount === 1 ? "" : "s"}`
+    }
+  });
+  dayEl.addEventListener("click", () => selectDay(day, options));
+  dayEl.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      selectDay(day, options);
+    }
+  });
+  const header = dayEl.createDiv({ cls: "belki-calendar-day-header" });
+  header.createSpan({ cls: "belki-calendar-day-number", text: String(day.dayNumber) });
+  if (day.deadlineCount > 0) {
+    const deadline = header.createSpan({
+      cls: "belki-calendar-deadline-indicator",
+      attr: {
+        "aria-label": `${day.deadlineCount} deadline${day.deadlineCount === 1 ? "" : "s"}`
+      }
+    });
+    createBelkiIcon(deadline, "deadline", { size: 12 });
+    deadline.createSpan({ text: String(day.deadlineCount) });
+  }
+  if (day.totalCount > 0) {
+    dayEl.createDiv({
+      cls: "belki-calendar-mobile-count",
+      text: String(day.totalCount)
+    });
+  }
+  renderDayChips(dayEl, day, options);
+}
+function renderDayChips(parent, day, options) {
+  if (day.dueTasks.length === 0) {
+    return;
+  }
+  const chips = parent.createDiv({ cls: "belki-calendar-task-chips" });
+  const sortedTasks = options.sortTasks(day.dueTasks);
+  for (const task of sortedTasks.slice(0, MAX_VISIBLE_CHIPS)) {
+    const chip = chips.createEl("button", {
+      cls: "belki-calendar-task-chip",
+      text: task.title,
+      attr: { type: "button" }
+    });
+    chip.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      options.onOpenTask(task);
+    });
+  }
+  if (sortedTasks.length > MAX_VISIBLE_CHIPS) {
+    chips.createDiv({
+      cls: "belki-calendar-more",
+      text: `+${sortedTasks.length - MAX_VISIBLE_CHIPS} more`
+    });
+  }
+}
+function renderSelectedDay(parent, selectedDate, entries, options) {
+  const panel = parent.createDiv({ cls: "belki-calendar-selected" });
+  const header = panel.createDiv({ cls: "belki-calendar-selected-header" });
+  header.createEl("h2", { text: formatDateLabel(selectedDate) });
+  header.createSpan({
+    cls: "belki-calendar-selected-count",
+    text: `${entries.length} task${entries.length === 1 ? "" : "s"}`
+  });
+  if (entries.length === 0) {
+    panel.createDiv({
+      cls: "belki-calendar-empty",
+      text: "No dated tasks for this day."
+    });
+    return;
+  }
+  const list = panel.createDiv({ cls: "belki-calendar-selected-list" });
+  for (const entry of entries) {
+    const row = list.createEl("button", {
+      cls: `belki-calendar-selected-task is-${entry.role}`,
+      attr: { type: "button" }
+    });
+    row.addEventListener("click", () => options.onOpenTask(entry.task));
+    row.createSpan({
+      cls: "belki-calendar-selected-role",
+      text: entry.role === "due" ? "Due" : "Deadline"
+    });
+    const content = row.createDiv({ cls: "belki-calendar-selected-content" });
+    content.createDiv({ cls: "belki-calendar-selected-title", text: entry.task.title });
+    content.createDiv({
+      cls: "belki-calendar-selected-meta",
+      text: entry.role === "deadline" && entry.task.due ? `Due ${formatDateLabel(entry.task.due)}` : entry.task.deadline && entry.task.deadline !== selectedDate ? `Deadline ${formatDateLabel(entry.task.deadline)}` : ""
+    });
+  }
+}
+function selectDay(day, options) {
+  const month = day.isCurrentMonth ? options.month : calendarMonthFromIsoDate(day.date) || options.month;
+  options.onSelectDate(day.date, month);
+}
+function sortEntries(entries, sortTasks) {
+  return [
+    ...sortEntriesByRole(entries, "due", sortTasks),
+    ...sortEntriesByRole(entries, "deadline", sortTasks)
+  ];
+}
+function sortEntriesByRole(entries, role, sortTasks) {
+  const roleEntries = entries.filter((entry) => entry.role === role);
+  const entriesByTaskId = new Map(roleEntries.map((entry) => [entry.task.id, entry]));
+  return sortTasks(roleEntries.map((entry) => entry.task)).map((task) => entriesByTaskId.get(task.id)).filter((entry) => Boolean(entry));
+}
+
 // src/views/TaskBoardView.ts
 var VIEW_TYPE_BELKI = "belki-task-board";
 function markdownPreviewText(text) {
@@ -7085,6 +7404,8 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
     this.dailyNoteDate = null;
     this.dailyNoteSourcePath = null;
     this.activitySelectedDate = null;
+    this.calendarMonth = calendarMonthFromDate(/* @__PURE__ */ new Date());
+    this.calendarSelectedDate = todayIso();
     this.activityCache = null;
     this.draggedTaskId = null;
     this.sortPopoverOpen = false;
@@ -7382,6 +7703,7 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
     this.renderNavButton(nav, "Inbox", "inbox", this.getInboxTasks(activeTopLevel).length, "inbox");
     this.renderNavButton(nav, "Today", "today", this.getTodayTasks(activeTopLevel).length, "today");
     this.renderNavButton(nav, "Upcoming", "upcoming", this.getUpcomingTasks(activeTopLevel).length, "upcoming");
+    this.renderNavButton(nav, "Calendar", "calendar", void 0, "calendar");
     this.renderNavButton(nav, "Filters & Labels", "filters", void 0, "filters");
     this.renderNavButton(nav, "Projects", "projects", void 0, "projects");
     this.renderNavButton(nav, "Activity", "activity", void 0, "activity");
@@ -7507,7 +7829,7 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
       cls: "belki-subtitle",
       text: activityData ? `${activityData.allTimeCount} completed task${activityData.allTimeCount === 1 ? "" : "s"}` : `${visible.length} task${visible.length === 1 ? "" : "s"}`
     });
-    if (this.mode !== "activity" && this.mode !== "daily-note") {
+    if (this.mode !== "activity" && this.mode !== "daily-note" && this.mode !== "calendar") {
       this.renderSortingControl(header);
     }
     const sections = main.createDiv({ cls: "belki-sections" });
@@ -7830,6 +8152,27 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
     }
     if (this.mode === "activity") {
       this.renderActivityView(parent, allTasks);
+      return;
+    }
+    if (this.mode === "calendar") {
+      renderCalendarView({
+        parent,
+        month: this.calendarMonth,
+        selectedDate: this.calendarSelectedDate,
+        tasks: this.sortTasks(active.filter(hasCalendarDate)),
+        sortTasks: (tasks) => this.sortTasks(tasks),
+        onNavigate: (month, selectedDate) => {
+          this.calendarMonth = month;
+          this.calendarSelectedDate = selectedDate;
+          this.render();
+        },
+        onSelectDate: (date, month) => {
+          this.calendarSelectedDate = date;
+          this.calendarMonth = month;
+          this.render();
+        },
+        onOpenTask: (task) => this.openTaskDetail(task)
+      });
       return;
     }
     if (this.mode === "daily-note") {
@@ -8751,6 +9094,9 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
     if (this.mode === "activity") {
       return [];
     }
+    if (this.mode === "calendar") {
+      return this.sortTasks(active.filter(hasCalendarDate));
+    }
     if (this.mode === "daily-note") {
       return this.dailyNoteDate ? this.store.getCompletedTasksForDate(this.dailyNoteDate) : [];
     }
@@ -8873,6 +9219,9 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
     }
     if (this.mode === "activity") {
       return "Activity";
+    }
+    if (this.mode === "calendar") {
+      return "Calendar";
     }
     if (this.mode === "daily-note") {
       return "Daily Note";

--- a/main.js
+++ b/main.js
@@ -8183,12 +8183,12 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
         onNavigate: (month, selectedDate) => {
           this.calendarMonth = month;
           this.calendarSelectedDate = selectedDate;
-          this.render();
+          this.renderPreservingMainScroll();
         },
         onSelectDate: (date, month) => {
           this.calendarSelectedDate = date;
           this.calendarMonth = month;
-          this.render();
+          this.renderPreservingMainScroll();
         },
         onOpenTask: (task) => this.openTaskDetail(task)
       });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "node esbuild.config.mjs",
     "build:css": "node scripts/build-styles.mjs",
-    "build": "pnpm run build:css && tsc --noEmit --skipLibCheck && node esbuild.config.mjs production"
+    "build": "pnpm run build:css && tsc --noEmit --skipLibCheck && node esbuild.config.mjs production",
+    "test": "node -e \"require('node:fs').rmSync('tmp/test-dist',{recursive:true,force:true})\" && tsc --project tsconfig.test.json && node --test tmp/test-dist/tests"
   },
   "keywords": [
     "obsidian",

--- a/src/styles/09-calendar.css
+++ b/src/styles/09-calendar.css
@@ -1,7 +1,7 @@
 
 .belki-calendar {
   display: grid;
-  gap: 18px;
+  gap: 20px;
 }
 
 .belki-calendar-toolbar {
@@ -13,8 +13,8 @@
 
 .belki-calendar-month-label {
   color: var(--belki-text);
-  font-size: 16px;
-  font-weight: 700;
+  font-size: 18px;
+  font-weight: 750;
   min-width: 0;
   text-align: center;
 }
@@ -49,36 +49,38 @@
 }
 
 .belki-calendar-grid {
-  border: 1px solid var(--belki-border);
-  border-radius: var(--belki-radius);
+  background: var(--belki-surface);
+  border: 1px solid color-mix(in srgb, var(--belki-border) 72%, transparent);
+  border-radius: 8px;
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
   overflow: hidden;
 }
 
 .belki-calendar-weekday {
-  background: var(--belki-sidebar-bg);
-  border-bottom: 1px solid var(--belki-border);
+  background: transparent;
+  border-bottom: 1px solid color-mix(in srgb, var(--belki-border) 72%, transparent);
   color: var(--belki-muted);
   font-size: 11px;
   font-weight: 700;
   min-width: 0;
-  padding: 8px 6px;
+  padding: 10px 6px;
   text-align: center;
   text-transform: uppercase;
 }
 
 .belki-calendar-day {
   background: var(--belki-surface);
-  border-bottom: 1px solid var(--belki-border);
-  border-right: 1px solid var(--belki-border);
+  border-bottom: 1px solid color-mix(in srgb, var(--belki-border) 70%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--belki-border) 70%, transparent);
   cursor: pointer;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
-  min-height: 112px;
+  min-height: 148px;
   min-width: 0;
-  padding: 7px;
+  padding: 10px;
   position: relative;
+  transition: background var(--belki-transition), box-shadow var(--belki-transition);
 }
 
 .belki-calendar-day:nth-child(7n + 7) {
@@ -100,7 +102,7 @@
 }
 
 .belki-calendar-day.is-selected {
-  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--belki-accent) 28%, transparent);
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--belki-accent) 30%, transparent);
 }
 
 .belki-calendar-day.is-today .belki-calendar-day-number {
@@ -125,11 +127,11 @@
   border-radius: 999px;
   color: inherit;
   display: inline-flex;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 700;
-  height: 24px;
+  height: 26px;
   justify-content: center;
-  min-width: 24px;
+  min-width: 26px;
   padding: 0 6px;
 }
 
@@ -154,8 +156,8 @@
 .belki-calendar-task-chips {
   align-content: start;
   display: grid;
-  gap: 4px;
-  margin-top: 6px;
+  gap: 6px;
+  margin-top: 8px;
   min-width: 0;
 }
 
@@ -171,13 +173,13 @@
   display: -webkit-box;
   font: inherit;
   font-size: 12px;
-  height: 36px;
+  height: 38px;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   line-height: 1.25;
   min-width: 0;
   overflow: hidden;
-  padding: 4px 6px;
+  padding: 5px 7px;
   text-align: left;
   white-space: normal;
 }
@@ -202,14 +204,14 @@
   color: var(--belki-muted);
   font-size: 12px;
   line-height: 1.3;
-  padding: 1px 6px;
+  padding: 0 7px;
 }
 
 .belki-calendar-selected {
-  border-top: 1px solid var(--belki-border);
+  border-top: 1px solid color-mix(in srgb, var(--belki-border) 72%, transparent);
   display: grid;
-  gap: 10px;
-  padding-top: 14px;
+  gap: 12px;
+  padding-top: 16px;
 }
 
 .belki-calendar-selected-header {
@@ -249,7 +251,7 @@
   appearance: none;
   background: transparent;
   border: 0;
-  border-bottom: 1px solid var(--belki-border);
+  border-bottom: 1px solid color-mix(in srgb, var(--belki-border) 72%, transparent);
   border-left: 3px solid transparent;
   border-radius: 0;
   box-shadow: none;
@@ -257,10 +259,10 @@
   cursor: pointer;
   display: grid;
   font: inherit;
-  gap: 10px;
+  gap: 12px;
   grid-template-columns: 68px minmax(0, 1fr);
-  min-height: 46px;
-  padding: 8px 0;
+  min-height: 54px;
+  padding: 10px 0;
   text-align: left;
 }
 
@@ -303,11 +305,14 @@
 
 .belki-calendar-selected-title {
   color: var(--belki-text);
+  display: -webkit-box;
   font-size: 13px;
   font-weight: 600;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-height: 1.3;
+  white-space: normal;
 }
 
 .belki-calendar-selected-meta {

--- a/src/styles/09-calendar.css
+++ b/src/styles/09-calendar.css
@@ -168,17 +168,18 @@
   box-shadow: none;
   color: var(--belki-text);
   cursor: pointer;
-  display: block;
+  display: -webkit-box;
   font: inherit;
   font-size: 12px;
+  height: 36px;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   line-height: 1.25;
-  min-height: 24px;
   min-width: 0;
   overflow: hidden;
   padding: 4px 6px;
   text-align: left;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .belki-calendar-task-chip.belki-calendar-has-project-color {
@@ -257,7 +258,7 @@
   display: grid;
   font: inherit;
   gap: 10px;
-  grid-template-columns: 74px minmax(0, 1fr);
+  grid-template-columns: 68px minmax(0, 1fr);
   min-height: 46px;
   padding: 8px 0;
   text-align: left;

--- a/src/styles/09-calendar.css
+++ b/src/styles/09-calendar.css
@@ -1,0 +1,385 @@
+
+.belki-calendar {
+  display: grid;
+  gap: 18px;
+}
+
+.belki-calendar-toolbar {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 34px minmax(0, 1fr) 34px auto;
+}
+
+.belki-calendar-month-label {
+  color: var(--belki-text);
+  font-size: 16px;
+  font-weight: 700;
+  min-width: 0;
+  text-align: center;
+}
+
+.belki-calendar-nav-button,
+.belki-calendar-today-button {
+  align-items: center;
+  appearance: none;
+  background: var(--belki-hover);
+  border: 0;
+  border-radius: var(--belki-radius);
+  box-shadow: none;
+  color: var(--belki-text);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  justify-content: center;
+  min-height: 34px;
+  padding: 0 10px;
+}
+
+.belki-calendar-nav-button {
+  aspect-ratio: 1;
+  padding: 0;
+}
+
+.belki-calendar-nav-button:hover,
+.belki-calendar-today-button:hover {
+  background: var(--belki-border);
+}
+
+.belki-calendar-grid {
+  border: 1px solid var(--belki-border);
+  border-radius: var(--belki-radius);
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  overflow: hidden;
+}
+
+.belki-calendar-weekday {
+  background: var(--belki-sidebar-bg);
+  border-bottom: 1px solid var(--belki-border);
+  color: var(--belki-muted);
+  font-size: 11px;
+  font-weight: 700;
+  min-width: 0;
+  padding: 8px 6px;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.belki-calendar-day {
+  background: var(--belki-surface);
+  border-bottom: 1px solid var(--belki-border);
+  border-right: 1px solid var(--belki-border);
+  cursor: pointer;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 112px;
+  min-width: 0;
+  padding: 7px;
+  position: relative;
+}
+
+.belki-calendar-day:nth-child(7n + 7) {
+  border-right: 0;
+}
+
+.belki-calendar-day:nth-last-child(-n + 7) {
+  border-bottom: 0;
+}
+
+.belki-calendar-day:hover,
+.belki-calendar-day:focus-visible {
+  background: var(--belki-hover);
+  outline: none;
+}
+
+.belki-calendar-day.is-muted {
+  color: var(--belki-faint);
+}
+
+.belki-calendar-day.is-selected {
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--belki-accent) 28%, transparent);
+}
+
+.belki-calendar-day.is-today .belki-calendar-day-number {
+  background: var(--belki-accent);
+  color: var(--belki-on-accent);
+}
+
+.belki-calendar-day.is-overdue {
+  background: color-mix(in srgb, var(--belki-danger) 5%, var(--belki-surface));
+}
+
+.belki-calendar-day-header {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.belki-calendar-day-number {
+  align-items: center;
+  border-radius: 999px;
+  color: inherit;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 700;
+  height: 24px;
+  justify-content: center;
+  min-width: 24px;
+  padding: 0 6px;
+}
+
+.belki-calendar-deadline-indicator {
+  align-items: center;
+  background: color-mix(in srgb, var(--belki-danger) 10%, transparent);
+  border-radius: 999px;
+  color: var(--belki-danger);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 700;
+  gap: 3px;
+  min-height: 20px;
+  padding: 0 6px;
+}
+
+.belki-calendar-mobile-count {
+  display: none;
+}
+
+.belki-calendar-task-chips {
+  align-content: start;
+  display: grid;
+  gap: 4px;
+  margin-top: 6px;
+  min-width: 0;
+}
+
+.belki-calendar-task-chip {
+  appearance: none;
+  background: var(--belki-chip-bg);
+  border: 1px solid transparent;
+  border-radius: 5px;
+  box-shadow: none;
+  color: var(--belki-text);
+  cursor: pointer;
+  display: block;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.25;
+  min-height: 24px;
+  min-width: 0;
+  overflow: hidden;
+  padding: 4px 6px;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.belki-calendar-task-chip:hover,
+.belki-calendar-task-chip:focus-visible {
+  background: var(--belki-border);
+  outline: none;
+}
+
+.belki-calendar-more {
+  color: var(--belki-muted);
+  font-size: 12px;
+  line-height: 1.3;
+  padding: 1px 6px;
+}
+
+.belki-calendar-selected {
+  border-top: 1px solid var(--belki-border);
+  display: grid;
+  gap: 10px;
+  padding-top: 14px;
+}
+
+.belki-calendar-selected-header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.belki-calendar-selected-header h2 {
+  color: var(--belki-text);
+  font-size: 15px;
+  font-weight: 700;
+  margin: 0;
+  min-width: 0;
+}
+
+.belki-calendar-selected-count {
+  color: var(--belki-muted);
+  flex: 0 0 auto;
+  font-size: 12px;
+}
+
+.belki-calendar-empty {
+  color: var(--belki-muted);
+  font-size: 13px;
+  padding: 6px 0;
+}
+
+.belki-calendar-selected-list {
+  display: grid;
+}
+
+.belki-calendar-selected-task {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--belki-border);
+  border-radius: 0;
+  box-shadow: none;
+  color: var(--belki-text);
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  gap: 10px;
+  grid-template-columns: 74px minmax(0, 1fr);
+  min-height: 46px;
+  padding: 8px 0;
+  text-align: left;
+}
+
+.belki-calendar-selected-task:hover,
+.belki-calendar-selected-task:focus-visible {
+  background: var(--belki-hover);
+  outline: none;
+}
+
+.belki-calendar-selected-role {
+  border: 1px solid var(--belki-border);
+  border-radius: 999px;
+  color: var(--belki-muted);
+  font-size: 11px;
+  font-weight: 700;
+  justify-self: start;
+  padding: 3px 7px;
+  text-transform: uppercase;
+}
+
+.belki-calendar-selected-task.is-deadline .belki-calendar-selected-role {
+  border-color: color-mix(in srgb, var(--belki-danger) 24%, var(--belki-border));
+  color: var(--belki-danger);
+}
+
+.belki-calendar-selected-content {
+  min-width: 0;
+}
+
+.belki-calendar-selected-title {
+  color: var(--belki-text);
+  font-size: 13px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.belki-calendar-selected-meta {
+  color: var(--belki-muted);
+  font-size: 12px;
+  margin-top: 2px;
+  min-height: 15px;
+}
+
+@media (max-width: 720px) {
+  .belki-calendar {
+    gap: 14px;
+  }
+
+  .belki-calendar-toolbar {
+    grid-template-columns: 34px minmax(0, 1fr) 34px;
+  }
+
+  .belki-calendar-today-button {
+    grid-column: 1 / -1;
+    justify-self: stretch;
+  }
+
+  .belki-calendar-weekday {
+    font-size: 10px;
+    padding: 7px 2px;
+  }
+
+  .belki-calendar-day {
+    min-height: 54px;
+    padding: 5px;
+  }
+
+  .belki-calendar-day-number {
+    font-size: 11px;
+    height: 22px;
+    min-width: 22px;
+    padding: 0 5px;
+  }
+
+  .belki-calendar-deadline-indicator {
+    font-size: 0;
+    gap: 0;
+    min-height: 8px;
+    min-width: 8px;
+    padding: 0;
+  }
+
+  .belki-calendar-deadline-indicator .belki-icon {
+    display: none;
+  }
+
+  .belki-calendar-task-chips {
+    display: none;
+  }
+
+  .belki-calendar-mobile-count {
+    align-self: end;
+    background: var(--belki-chip-bg);
+    border-radius: 999px;
+    color: var(--belki-muted);
+    display: inline-flex;
+    font-size: 11px;
+    font-weight: 700;
+    justify-content: center;
+    justify-self: start;
+    line-height: 1;
+    min-width: 18px;
+    padding: 4px 6px;
+  }
+
+  .belki-calendar-selected-task {
+    grid-template-columns: 68px minmax(0, 1fr);
+  }
+}
+
+.belki-root.is-mobile .belki-calendar-task-chips {
+  display: none;
+}
+
+.belki-root.is-mobile .belki-calendar-day {
+  min-height: 54px;
+  padding: 5px;
+}
+
+.belki-root.is-mobile .belki-calendar-mobile-count {
+  align-self: end;
+  background: var(--belki-chip-bg);
+  border-radius: 999px;
+  color: var(--belki-muted);
+  display: inline-flex;
+  font-size: 11px;
+  font-weight: 700;
+  justify-content: center;
+  justify-self: start;
+  line-height: 1;
+  min-width: 18px;
+  padding: 4px 6px;
+}

--- a/src/styles/09-calendar.css
+++ b/src/styles/09-calendar.css
@@ -163,6 +163,7 @@
   appearance: none;
   background: var(--belki-chip-bg);
   border: 1px solid transparent;
+  border-left: 3px solid transparent;
   border-radius: 5px;
   box-shadow: none;
   color: var(--belki-text);
@@ -180,10 +181,20 @@
   white-space: nowrap;
 }
 
+.belki-calendar-task-chip.belki-calendar-has-project-color {
+  background: var(--belki-calendar-project-bg);
+  border-left-color: var(--belki-calendar-project-color);
+}
+
 .belki-calendar-task-chip:hover,
 .belki-calendar-task-chip:focus-visible {
   background: var(--belki-border);
   outline: none;
+}
+
+.belki-calendar-task-chip.belki-calendar-has-project-color:hover,
+.belki-calendar-task-chip.belki-calendar-has-project-color:focus-visible {
+  background: color-mix(in srgb, var(--belki-calendar-project-bg) 72%, var(--belki-hover));
 }
 
 .belki-calendar-more {
@@ -238,6 +249,7 @@
   background: transparent;
   border: 0;
   border-bottom: 1px solid var(--belki-border);
+  border-left: 3px solid transparent;
   border-radius: 0;
   box-shadow: none;
   color: var(--belki-text);
@@ -251,10 +263,21 @@
   text-align: left;
 }
 
+.belki-calendar-selected-task.belki-calendar-has-project-color {
+  background: color-mix(in srgb, var(--belki-calendar-project-bg) 58%, transparent);
+  border-left-color: var(--belki-calendar-project-color);
+  padding-left: 8px;
+}
+
 .belki-calendar-selected-task:hover,
 .belki-calendar-selected-task:focus-visible {
   background: var(--belki-hover);
   outline: none;
+}
+
+.belki-calendar-selected-task.belki-calendar-has-project-color:hover,
+.belki-calendar-selected-task.belki-calendar-has-project-color:focus-visible {
+  background: color-mix(in srgb, var(--belki-calendar-project-bg) 72%, var(--belki-hover));
 }
 
 .belki-calendar-selected-role {

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,7 @@ export type BoardViewMode =
   | "upcoming"
   | "projects"
   | "activity"
+  | "calendar"
   | "completed"
   | "search"
   | "filters"

--- a/src/views/TaskBoardView.ts
+++ b/src/views/TaskBoardView.ts
@@ -992,12 +992,12 @@ export class TaskBoardView extends ItemView {
         onNavigate: (month, selectedDate) => {
           this.calendarMonth = month;
           this.calendarSelectedDate = selectedDate;
-          this.render();
+          this.renderPreservingMainScroll();
         },
         onSelectDate: (date, month) => {
           this.calendarSelectedDate = date;
           this.calendarMonth = month;
-          this.render();
+          this.renderPreservingMainScroll();
         },
         onOpenTask: (task) => this.openTaskDetail(task)
       });

--- a/src/views/TaskBoardView.ts
+++ b/src/views/TaskBoardView.ts
@@ -51,6 +51,10 @@ import { openLabelActionsMenu as openLabelActionsMenuElement } from "./labels/la
 import { renderFiltersAndLabelsView } from "./filters/FiltersAndLabelsView";
 import type { FilterDefinition } from "./filters/FiltersAndLabelsView";
 import { renderTaskActionMenu, renderTaskActions } from "./tasks/taskActions";
+import { renderCalendarView } from "./calendar/CalendarView";
+import { hasCalendarDate } from "./calendar/calendarModel";
+import { calendarMonthFromDate } from "./calendar/calendarUtils";
+import type { CalendarMonth } from "./calendar/calendarTypes";
 
 export const VIEW_TYPE_BELKI = "belki-task-board";
 
@@ -96,6 +100,8 @@ export class TaskBoardView extends ItemView {
   private dailyNoteDate: string | null = null;
   private dailyNoteSourcePath: string | null = null;
   private activitySelectedDate: string | null = null;
+  private calendarMonth: CalendarMonth = calendarMonthFromDate(new Date());
+  private calendarSelectedDate = todayIso();
   private activityCache: { signature: string; data: ActivityData } | null = null;
   private draggedTaskId: string | null = null;
   private sortPopoverOpen = false;
@@ -449,6 +455,7 @@ export class TaskBoardView extends ItemView {
     this.renderNavButton(nav, "Inbox", "inbox", this.getInboxTasks(activeTopLevel).length, "inbox");
     this.renderNavButton(nav, "Today", "today", this.getTodayTasks(activeTopLevel).length, "today");
     this.renderNavButton(nav, "Upcoming", "upcoming", this.getUpcomingTasks(activeTopLevel).length, "upcoming");
+    this.renderNavButton(nav, "Calendar", "calendar", undefined, "calendar");
     this.renderNavButton(nav, "Filters & Labels", "filters", undefined, "filters");
     this.renderNavButton(nav, "Projects", "projects", undefined, "projects");
     this.renderNavButton(nav, "Activity", "activity", undefined, "activity");
@@ -540,7 +547,7 @@ export class TaskBoardView extends ItemView {
     label: string,
     mode: BoardViewMode,
     count?: number,
-    iconKey?: keyof BelkiIconSettings
+    iconKey?: keyof BelkiIconSettings | "calendar"
   ): void {
     const button = parent.createEl("button", { cls: "belki-nav-button" });
     const active =
@@ -599,7 +606,7 @@ export class TaskBoardView extends ItemView {
         ? `${activityData.allTimeCount} completed task${activityData.allTimeCount === 1 ? "" : "s"}`
         : `${visible.length} task${visible.length === 1 ? "" : "s"}`
     });
-    if (this.mode !== "activity" && this.mode !== "daily-note") {
+    if (this.mode !== "activity" && this.mode !== "daily-note" && this.mode !== "calendar") {
       this.renderSortingControl(header);
     }
 
@@ -971,6 +978,28 @@ export class TaskBoardView extends ItemView {
 
     if (this.mode === "activity") {
       this.renderActivityView(parent, allTasks);
+      return;
+    }
+
+    if (this.mode === "calendar") {
+      renderCalendarView({
+        parent,
+        month: this.calendarMonth,
+        selectedDate: this.calendarSelectedDate,
+        tasks: this.sortTasks(active.filter(hasCalendarDate)),
+        sortTasks: (tasks) => this.sortTasks(tasks),
+        onNavigate: (month, selectedDate) => {
+          this.calendarMonth = month;
+          this.calendarSelectedDate = selectedDate;
+          this.render();
+        },
+        onSelectDate: (date, month) => {
+          this.calendarSelectedDate = date;
+          this.calendarMonth = month;
+          this.render();
+        },
+        onOpenTask: (task) => this.openTaskDetail(task)
+      });
       return;
     }
 
@@ -2034,6 +2063,10 @@ export class TaskBoardView extends ItemView {
       return [];
     }
 
+    if (this.mode === "calendar") {
+      return this.sortTasks(active.filter(hasCalendarDate));
+    }
+
     if (this.mode === "daily-note") {
       return this.dailyNoteDate
         ? this.store.getCompletedTasksForDate(this.dailyNoteDate)
@@ -2195,6 +2228,9 @@ export class TaskBoardView extends ItemView {
     }
     if (this.mode === "activity") {
       return "Activity";
+    }
+    if (this.mode === "calendar") {
+      return "Calendar";
     }
     if (this.mode === "daily-note") {
       return "Daily Note";

--- a/src/views/TaskBoardView.ts
+++ b/src/views/TaskBoardView.ts
@@ -987,6 +987,7 @@ export class TaskBoardView extends ItemView {
         month: this.calendarMonth,
         selectedDate: this.calendarSelectedDate,
         tasks: this.sortTasks(active.filter(hasCalendarDate)),
+        projectColors: this.settings.projectColors,
         sortTasks: (tasks) => this.sortTasks(tasks),
         onNavigate: (month, selectedDate) => {
           this.calendarMonth = month;

--- a/src/views/calendar/CalendarView.ts
+++ b/src/views/calendar/CalendarView.ts
@@ -1,4 +1,6 @@
+import { getProjectColor } from "../../colors";
 import { formatDateLabel, todayIso } from "../../dateUtils";
+import { normalizeTaskProject } from "../../projects";
 import type { BelkiTask } from "../../types";
 import { createBelkiIcon } from "../../ui/components/BelkiIcon";
 import {
@@ -21,6 +23,7 @@ interface RenderCalendarViewOptions {
   month: CalendarMonth;
   selectedDate: string;
   tasks: BelkiTask[];
+  projectColors: Record<string, string>;
   sortTasks: (tasks: BelkiTask[]) => BelkiTask[];
   onNavigate: (month: CalendarMonth, selectedDate: string) => void;
   onSelectDate: (date: string, month: CalendarMonth) => void;
@@ -177,6 +180,7 @@ function renderDayChips(
       text: task.title,
       attr: { type: "button" }
     });
+    applyProjectColor(chip, task, options.projectColors);
     chip.addEventListener("click", (event) => {
       event.preventDefault();
       event.stopPropagation();
@@ -220,6 +224,7 @@ function renderSelectedDay(
       cls: `belki-calendar-selected-task is-${entry.role}`,
       attr: { type: "button" }
     });
+    applyProjectColor(row, entry.task, options.projectColors);
     row.addEventListener("click", () => options.onOpenTask(entry.task));
     row.createSpan({
       cls: "belki-calendar-selected-role",
@@ -227,15 +232,37 @@ function renderSelectedDay(
     });
     const content = row.createDiv({ cls: "belki-calendar-selected-content" });
     content.createDiv({ cls: "belki-calendar-selected-title", text: entry.task.title });
+    const project = normalizeTaskProject(entry.task.project);
     content.createDiv({
       cls: "belki-calendar-selected-meta",
-      text: entry.role === "deadline" && entry.task.due
-        ? `Due ${formatDateLabel(entry.task.due)}`
-        : entry.task.deadline && entry.task.deadline !== selectedDate
-          ? `Deadline ${formatDateLabel(entry.task.deadline)}`
-          : ""
+      text: [
+        project,
+        entry.role === "deadline" && entry.task.due
+          ? `Due ${formatDateLabel(entry.task.due)}`
+          : entry.task.deadline && entry.task.deadline !== selectedDate
+            ? `Deadline ${formatDateLabel(entry.task.deadline)}`
+            : ""
+      ].filter(Boolean).join(" · ")
     });
   }
+}
+
+function applyProjectColor(
+  element: HTMLElement,
+  task: BelkiTask,
+  projectColors: Record<string, string>
+): void {
+  const project = normalizeTaskProject(task.project);
+  if (!project) {
+    return;
+  }
+
+  const color = getProjectColor(project, projectColors);
+  element.addClass("belki-calendar-has-project-color");
+  element.setCssProps({
+    "--belki-calendar-project-bg": color.light,
+    "--belki-calendar-project-color": color.regular
+  });
 }
 
 function selectDay(day: CalendarDay, options: RenderCalendarViewOptions): void {

--- a/src/views/calendar/CalendarView.ts
+++ b/src/views/calendar/CalendarView.ts
@@ -1,0 +1,268 @@
+import { formatDateLabel, todayIso } from "../../dateUtils";
+import type { BelkiTask } from "../../types";
+import { createBelkiIcon } from "../../ui/components/BelkiIcon";
+import {
+  buildCalendarTaskGroups,
+  buildMonthGrid,
+  getCalendarTasksForDate
+} from "./calendarModel";
+import {
+  addCalendarMonths,
+  calendarMonthFromDate,
+  calendarMonthFromIsoDate,
+  CALENDAR_WEEKDAY_LABELS,
+  formatCalendarMonthLabel,
+  selectedDateForCalendarMonth
+} from "./calendarUtils";
+import type { CalendarDay, CalendarMonth, CalendarTaskEntry } from "./calendarTypes";
+
+interface RenderCalendarViewOptions {
+  parent: HTMLElement;
+  month: CalendarMonth;
+  selectedDate: string;
+  tasks: BelkiTask[];
+  sortTasks: (tasks: BelkiTask[]) => BelkiTask[];
+  onNavigate: (month: CalendarMonth, selectedDate: string) => void;
+  onSelectDate: (date: string, month: CalendarMonth) => void;
+  onOpenTask: (task: BelkiTask) => void;
+}
+
+const MAX_VISIBLE_CHIPS = 3;
+
+export function renderCalendarView(options: RenderCalendarViewOptions): void {
+  const taskGroups = buildCalendarTaskGroups(options.tasks);
+  const today = todayIso();
+  const days = buildMonthGrid({
+    month: options.month,
+    taskGroups,
+    selectedDate: options.selectedDate,
+    today
+  });
+  const selectedEntries = sortEntries(
+    getCalendarTasksForDate(taskGroups, options.selectedDate),
+    options.sortTasks
+  );
+
+  const calendar = options.parent.createDiv({ cls: "belki-calendar" });
+  renderCalendarToolbar(calendar, options, today);
+  renderCalendarGrid(calendar, days, options);
+  renderSelectedDay(calendar, options.selectedDate, selectedEntries, options);
+}
+
+function renderCalendarToolbar(
+  parent: HTMLElement,
+  options: RenderCalendarViewOptions,
+  today: string
+): void {
+  const toolbar = parent.createDiv({ cls: "belki-calendar-toolbar" });
+  const previous = toolbar.createEl("button", {
+    cls: "belki-calendar-nav-button",
+    attr: { type: "button", "aria-label": "Previous month" }
+  });
+  createBelkiIcon(previous, "chevron-left");
+  previous.addEventListener("click", () => {
+    const month = addCalendarMonths(options.month, -1);
+    options.onNavigate(month, selectedDateForCalendarMonth(month, options.selectedDate));
+  });
+
+  toolbar.createDiv({
+    cls: "belki-calendar-month-label",
+    text: formatCalendarMonthLabel(options.month)
+  });
+
+  const next = toolbar.createEl("button", {
+    cls: "belki-calendar-nav-button",
+    attr: { type: "button", "aria-label": "Next month" }
+  });
+  createBelkiIcon(next, "chevron-right");
+  next.addEventListener("click", () => {
+    const month = addCalendarMonths(options.month, 1);
+    options.onNavigate(month, selectedDateForCalendarMonth(month, options.selectedDate));
+  });
+
+  toolbar
+    .createEl("button", {
+      cls: "belki-calendar-today-button",
+      text: "Today",
+      attr: { type: "button" }
+    })
+    .addEventListener("click", () => {
+      options.onNavigate(calendarMonthFromDate(new Date()), today);
+    });
+}
+
+function renderCalendarGrid(
+  parent: HTMLElement,
+  days: CalendarDay[],
+  options: RenderCalendarViewOptions
+): void {
+  const grid = parent.createDiv({ cls: "belki-calendar-grid" });
+  for (const label of CALENDAR_WEEKDAY_LABELS) {
+    grid.createDiv({ cls: "belki-calendar-weekday", text: label });
+  }
+
+  for (const day of days) {
+    renderCalendarDay(grid, day, options);
+  }
+}
+
+function renderCalendarDay(
+  parent: HTMLElement,
+  day: CalendarDay,
+  options: RenderCalendarViewOptions
+): void {
+  const classes = [
+    "belki-calendar-day",
+    day.isCurrentMonth ? undefined : "is-muted",
+    day.isToday ? "is-today" : undefined,
+    day.isSelected ? "is-selected" : undefined,
+    day.isOverdue ? "is-overdue" : undefined,
+    day.totalCount > 0 ? "has-tasks" : undefined
+  ].filter(Boolean).join(" ");
+
+  const dayEl = parent.createEl("div", {
+    cls: classes,
+    attr: {
+      role: "button",
+      tabindex: "0",
+      "aria-label": `${formatDateLabel(day.date)}, ${day.totalCount} task${day.totalCount === 1 ? "" : "s"}`
+    }
+  });
+  dayEl.addEventListener("click", () => selectDay(day, options));
+  dayEl.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      selectDay(day, options);
+    }
+  });
+
+  const header = dayEl.createDiv({ cls: "belki-calendar-day-header" });
+  header.createSpan({ cls: "belki-calendar-day-number", text: String(day.dayNumber) });
+
+  if (day.deadlineCount > 0) {
+    const deadline = header.createSpan({
+      cls: "belki-calendar-deadline-indicator",
+      attr: {
+        "aria-label": `${day.deadlineCount} deadline${day.deadlineCount === 1 ? "" : "s"}`
+      }
+    });
+    createBelkiIcon(deadline, "deadline", { size: 12 });
+    deadline.createSpan({ text: String(day.deadlineCount) });
+  }
+
+  if (day.totalCount > 0) {
+    dayEl.createDiv({
+      cls: "belki-calendar-mobile-count",
+      text: String(day.totalCount)
+    });
+  }
+
+  renderDayChips(dayEl, day, options);
+}
+
+function renderDayChips(
+  parent: HTMLElement,
+  day: CalendarDay,
+  options: RenderCalendarViewOptions
+): void {
+  if (day.dueTasks.length === 0) {
+    return;
+  }
+
+  const chips = parent.createDiv({ cls: "belki-calendar-task-chips" });
+  const sortedTasks = options.sortTasks(day.dueTasks);
+  for (const task of sortedTasks.slice(0, MAX_VISIBLE_CHIPS)) {
+    const chip = chips.createEl("button", {
+      cls: "belki-calendar-task-chip",
+      text: task.title,
+      attr: { type: "button" }
+    });
+    chip.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      options.onOpenTask(task);
+    });
+  }
+
+  if (sortedTasks.length > MAX_VISIBLE_CHIPS) {
+    chips.createDiv({
+      cls: "belki-calendar-more",
+      text: `+${sortedTasks.length - MAX_VISIBLE_CHIPS} more`
+    });
+  }
+}
+
+function renderSelectedDay(
+  parent: HTMLElement,
+  selectedDate: string,
+  entries: CalendarTaskEntry[],
+  options: RenderCalendarViewOptions
+): void {
+  const panel = parent.createDiv({ cls: "belki-calendar-selected" });
+  const header = panel.createDiv({ cls: "belki-calendar-selected-header" });
+  header.createEl("h2", { text: formatDateLabel(selectedDate) });
+  header.createSpan({
+    cls: "belki-calendar-selected-count",
+    text: `${entries.length} task${entries.length === 1 ? "" : "s"}`
+  });
+
+  if (entries.length === 0) {
+    panel.createDiv({
+      cls: "belki-calendar-empty",
+      text: "No dated tasks for this day."
+    });
+    return;
+  }
+
+  const list = panel.createDiv({ cls: "belki-calendar-selected-list" });
+  for (const entry of entries) {
+    const row = list.createEl("button", {
+      cls: `belki-calendar-selected-task is-${entry.role}`,
+      attr: { type: "button" }
+    });
+    row.addEventListener("click", () => options.onOpenTask(entry.task));
+    row.createSpan({
+      cls: "belki-calendar-selected-role",
+      text: entry.role === "due" ? "Due" : "Deadline"
+    });
+    const content = row.createDiv({ cls: "belki-calendar-selected-content" });
+    content.createDiv({ cls: "belki-calendar-selected-title", text: entry.task.title });
+    content.createDiv({
+      cls: "belki-calendar-selected-meta",
+      text: entry.role === "deadline" && entry.task.due
+        ? `Due ${formatDateLabel(entry.task.due)}`
+        : entry.task.deadline && entry.task.deadline !== selectedDate
+          ? `Deadline ${formatDateLabel(entry.task.deadline)}`
+          : ""
+    });
+  }
+}
+
+function selectDay(day: CalendarDay, options: RenderCalendarViewOptions): void {
+  const month = day.isCurrentMonth
+    ? options.month
+    : calendarMonthFromIsoDate(day.date) || options.month;
+  options.onSelectDate(day.date, month);
+}
+
+function sortEntries(
+  entries: CalendarTaskEntry[],
+  sortTasks: (tasks: BelkiTask[]) => BelkiTask[]
+): CalendarTaskEntry[] {
+  return [
+    ...sortEntriesByRole(entries, "due", sortTasks),
+    ...sortEntriesByRole(entries, "deadline", sortTasks)
+  ];
+}
+
+function sortEntriesByRole(
+  entries: CalendarTaskEntry[],
+  role: CalendarTaskEntry["role"],
+  sortTasks: (tasks: BelkiTask[]) => BelkiTask[]
+): CalendarTaskEntry[] {
+  const roleEntries = entries.filter((entry) => entry.role === role);
+  const entriesByTaskId = new Map(roleEntries.map((entry) => [entry.task.id, entry]));
+  return sortTasks(roleEntries.map((entry) => entry.task))
+    .map((task) => entriesByTaskId.get(task.id))
+    .filter((entry): entry is CalendarTaskEntry => Boolean(entry));
+}

--- a/src/views/calendar/calendarModel.ts
+++ b/src/views/calendar/calendarModel.ts
@@ -1,0 +1,126 @@
+import { todayIso, toIsoDate } from "../../dateUtils";
+import type { BelkiTask } from "../../types";
+import {
+  CALENDAR_WEEK_START,
+  isValidCalendarDate,
+  parseIsoDateLocal
+} from "./calendarUtils";
+import type {
+  CalendarDay,
+  CalendarMonth,
+  CalendarTaskEntry,
+  CalendarTaskGroups
+} from "./calendarTypes";
+
+interface BuildMonthGridOptions {
+  month: CalendarMonth;
+  taskGroups: CalendarTaskGroups;
+  selectedDate?: string;
+  today?: string;
+  weekStartsOn?: number;
+}
+
+export function buildCalendarTaskGroups(tasks: BelkiTask[]): CalendarTaskGroups {
+  const dueTasksByDate = new Map<string, BelkiTask[]>();
+  const deadlineTasksByDate = new Map<string, BelkiTask[]>();
+
+  for (const task of tasks) {
+    if (isValidCalendarDate(task.due)) {
+      appendTask(dueTasksByDate, task.due, task);
+    }
+
+    if (isValidCalendarDate(task.deadline) && task.deadline !== task.due) {
+      appendTask(deadlineTasksByDate, task.deadline, task);
+    }
+  }
+
+  sortTaskGroups(dueTasksByDate);
+  sortTaskGroups(deadlineTasksByDate);
+
+  return {
+    dueTasksByDate,
+    deadlineTasksByDate
+  };
+}
+
+export function buildMonthGrid(options: BuildMonthGridOptions): CalendarDay[] {
+  const today = isValidCalendarDate(options.today) ? options.today : todayIso();
+  const selectedDate = isValidCalendarDate(options.selectedDate)
+    ? options.selectedDate
+    : undefined;
+  const weekStartsOn = options.weekStartsOn ?? CALENDAR_WEEK_START;
+  const firstOfMonth = new Date(options.month.year, options.month.month, 1);
+  const leadingDayCount = (firstOfMonth.getDay() - weekStartsOn + 7) % 7;
+  const gridStart = new Date(options.month.year, options.month.month, 1 - leadingDayCount);
+  const days: CalendarDay[] = [];
+
+  for (let index = 0; index < 42; index += 1) {
+    const date = new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + index);
+    const isoDate = toIsoDate(date);
+    const dueTasks = options.taskGroups.dueTasksByDate.get(isoDate) || [];
+    const deadlineTasks = options.taskGroups.deadlineTasksByDate.get(isoDate) || [];
+
+    days.push({
+      date: isoDate,
+      dayNumber: date.getDate(),
+      isCurrentMonth:
+        date.getFullYear() === options.month.year &&
+        date.getMonth() === options.month.month,
+      isToday: isoDate === today,
+      isSelected: isoDate === selectedDate,
+      isOverdue: isoDate < today && dueTasks.some((task) => !task.completed),
+      dueTasks,
+      deadlineTasks,
+      deadlineCount: deadlineTasks.length,
+      totalCount: dueTasks.length + deadlineTasks.length
+    });
+  }
+
+  return days;
+}
+
+export function getCalendarTasksForDate(
+  taskGroups: CalendarTaskGroups,
+  date: string
+): CalendarTaskEntry[] {
+  const dueTasks = taskGroups.dueTasksByDate.get(date) || [];
+  const deadlineTasks = taskGroups.deadlineTasksByDate.get(date) || [];
+  const entries: CalendarTaskEntry[] = dueTasks.map((task) => ({ task, role: "due" }));
+  const seenTaskIds = new Set(dueTasks.map((task) => task.id));
+
+  for (const task of deadlineTasks) {
+    if (!seenTaskIds.has(task.id)) {
+      entries.push({ task, role: "deadline" });
+    }
+  }
+
+  return entries;
+}
+
+export function hasCalendarDate(task: BelkiTask): boolean {
+  return isValidCalendarDate(task.due) || isValidCalendarDate(task.deadline);
+}
+
+function appendTask(
+  groups: Map<string, BelkiTask[]>,
+  date: string,
+  task: BelkiTask
+): void {
+  const tasks = groups.get(date);
+  if (tasks) {
+    tasks.push(task);
+  } else {
+    groups.set(date, [task]);
+  }
+}
+
+function sortTaskGroups(groups: Map<string, BelkiTask[]>): void {
+  for (const [date, tasks] of groups) {
+    if (!parseIsoDateLocal(date)) {
+      groups.delete(date);
+      continue;
+    }
+
+    groups.set(date, [...tasks].sort((a, b) => a.order - b.order));
+  }
+}

--- a/src/views/calendar/calendarTypes.ts
+++ b/src/views/calendar/calendarTypes.ts
@@ -1,0 +1,31 @@
+import type { BelkiTask } from "../../types";
+
+export interface CalendarMonth {
+  year: number;
+  month: number;
+}
+
+export type CalendarTaskRole = "due" | "deadline";
+
+export interface CalendarTaskEntry {
+  task: BelkiTask;
+  role: CalendarTaskRole;
+}
+
+export interface CalendarTaskGroups {
+  dueTasksByDate: Map<string, BelkiTask[]>;
+  deadlineTasksByDate: Map<string, BelkiTask[]>;
+}
+
+export interface CalendarDay {
+  date: string;
+  dayNumber: number;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+  isSelected: boolean;
+  isOverdue: boolean;
+  dueTasks: BelkiTask[];
+  deadlineTasks: BelkiTask[];
+  deadlineCount: number;
+  totalCount: number;
+}

--- a/src/views/calendar/calendarUtils.ts
+++ b/src/views/calendar/calendarUtils.ts
@@ -1,0 +1,73 @@
+import { isIsoDate, toIsoDate } from "../../dateUtils";
+import type { CalendarMonth } from "./calendarTypes";
+
+export const CALENDAR_WEEK_START = 1;
+export const CALENDAR_WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+export function calendarMonthFromDate(date: Date): CalendarMonth {
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth()
+  };
+}
+
+export function calendarMonthFromIsoDate(value: string): CalendarMonth | null {
+  const date = parseIsoDateLocal(value);
+  return date ? calendarMonthFromDate(date) : null;
+}
+
+export function calendarMonthStartIso(month: CalendarMonth): string {
+  return toIsoDate(new Date(month.year, month.month, 1));
+}
+
+export function addCalendarMonths(month: CalendarMonth, amount: number): CalendarMonth {
+  return calendarMonthFromDate(new Date(month.year, month.month + amount, 1));
+}
+
+export function selectedDateForCalendarMonth(
+  month: CalendarMonth,
+  preferredDate?: string
+): string {
+  const preferred = preferredDate ? parseIsoDateLocal(preferredDate) : null;
+  const preferredDay = preferred?.getDate() || 1;
+  const day = Math.min(preferredDay, daysInCalendarMonth(month));
+  return toIsoDate(new Date(month.year, month.month, day));
+}
+
+export function isDateInCalendarMonth(value: string, month: CalendarMonth): boolean {
+  const date = parseIsoDateLocal(value);
+  return Boolean(date && date.getFullYear() === month.year && date.getMonth() === month.month);
+}
+
+export function formatCalendarMonthLabel(month: CalendarMonth): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "long",
+    year: "numeric"
+  }).format(new Date(month.year, month.month, 1));
+}
+
+export function parseIsoDateLocal(value: string | undefined): Date | null {
+  if (!isIsoDate(value)) {
+    return null;
+  }
+
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+}
+
+export function isValidCalendarDate(value: string | undefined): value is string {
+  return Boolean(parseIsoDateLocal(value));
+}
+
+function daysInCalendarMonth(month: CalendarMonth): number {
+  return new Date(month.year, month.month + 1, 0).getDate();
+}

--- a/styles.css
+++ b/styles.css
@@ -3635,6 +3635,7 @@ button.belki-label-actions-button:focus-visible {
   appearance: none;
   background: var(--belki-chip-bg);
   border: 1px solid transparent;
+  border-left: 3px solid transparent;
   border-radius: 5px;
   box-shadow: none;
   color: var(--belki-text);
@@ -3652,10 +3653,20 @@ button.belki-label-actions-button:focus-visible {
   white-space: nowrap;
 }
 
+.belki-calendar-task-chip.belki-calendar-has-project-color {
+  background: var(--belki-calendar-project-bg);
+  border-left-color: var(--belki-calendar-project-color);
+}
+
 .belki-calendar-task-chip:hover,
 .belki-calendar-task-chip:focus-visible {
   background: var(--belki-border);
   outline: none;
+}
+
+.belki-calendar-task-chip.belki-calendar-has-project-color:hover,
+.belki-calendar-task-chip.belki-calendar-has-project-color:focus-visible {
+  background: color-mix(in srgb, var(--belki-calendar-project-bg) 72%, var(--belki-hover));
 }
 
 .belki-calendar-more {
@@ -3710,6 +3721,7 @@ button.belki-label-actions-button:focus-visible {
   background: transparent;
   border: 0;
   border-bottom: 1px solid var(--belki-border);
+  border-left: 3px solid transparent;
   border-radius: 0;
   box-shadow: none;
   color: var(--belki-text);
@@ -3723,10 +3735,21 @@ button.belki-label-actions-button:focus-visible {
   text-align: left;
 }
 
+.belki-calendar-selected-task.belki-calendar-has-project-color {
+  background: color-mix(in srgb, var(--belki-calendar-project-bg) 58%, transparent);
+  border-left-color: var(--belki-calendar-project-color);
+  padding-left: 8px;
+}
+
 .belki-calendar-selected-task:hover,
 .belki-calendar-selected-task:focus-visible {
   background: var(--belki-hover);
   outline: none;
+}
+
+.belki-calendar-selected-task.belki-calendar-has-project-color:hover,
+.belki-calendar-selected-task.belki-calendar-has-project-color:focus-visible {
+  background: color-mix(in srgb, var(--belki-calendar-project-bg) 72%, var(--belki-hover));
 }
 
 .belki-calendar-selected-role {

--- a/styles.css
+++ b/styles.css
@@ -3640,17 +3640,18 @@ button.belki-label-actions-button:focus-visible {
   box-shadow: none;
   color: var(--belki-text);
   cursor: pointer;
-  display: block;
+  display: -webkit-box;
   font: inherit;
   font-size: 12px;
+  height: 36px;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   line-height: 1.25;
-  min-height: 24px;
   min-width: 0;
   overflow: hidden;
   padding: 4px 6px;
   text-align: left;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .belki-calendar-task-chip.belki-calendar-has-project-color {
@@ -3729,7 +3730,7 @@ button.belki-label-actions-button:focus-visible {
   display: grid;
   font: inherit;
   gap: 10px;
-  grid-template-columns: 74px minmax(0, 1fr);
+  grid-template-columns: 68px minmax(0, 1fr);
   min-height: 46px;
   padding: 8px 0;
   text-align: left;

--- a/styles.css
+++ b/styles.css
@@ -3473,7 +3473,7 @@ button.belki-label-actions-button:focus-visible {
 
 .belki-calendar {
   display: grid;
-  gap: 18px;
+  gap: 20px;
 }
 
 .belki-calendar-toolbar {
@@ -3485,8 +3485,8 @@ button.belki-label-actions-button:focus-visible {
 
 .belki-calendar-month-label {
   color: var(--belki-text);
-  font-size: 16px;
-  font-weight: 700;
+  font-size: 18px;
+  font-weight: 750;
   min-width: 0;
   text-align: center;
 }
@@ -3521,36 +3521,38 @@ button.belki-label-actions-button:focus-visible {
 }
 
 .belki-calendar-grid {
-  border: 1px solid var(--belki-border);
-  border-radius: var(--belki-radius);
+  background: var(--belki-surface);
+  border: 1px solid color-mix(in srgb, var(--belki-border) 72%, transparent);
+  border-radius: 8px;
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
   overflow: hidden;
 }
 
 .belki-calendar-weekday {
-  background: var(--belki-sidebar-bg);
-  border-bottom: 1px solid var(--belki-border);
+  background: transparent;
+  border-bottom: 1px solid color-mix(in srgb, var(--belki-border) 72%, transparent);
   color: var(--belki-muted);
   font-size: 11px;
   font-weight: 700;
   min-width: 0;
-  padding: 8px 6px;
+  padding: 10px 6px;
   text-align: center;
   text-transform: uppercase;
 }
 
 .belki-calendar-day {
   background: var(--belki-surface);
-  border-bottom: 1px solid var(--belki-border);
-  border-right: 1px solid var(--belki-border);
+  border-bottom: 1px solid color-mix(in srgb, var(--belki-border) 70%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--belki-border) 70%, transparent);
   cursor: pointer;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
-  min-height: 112px;
+  min-height: 148px;
   min-width: 0;
-  padding: 7px;
+  padding: 10px;
   position: relative;
+  transition: background var(--belki-transition), box-shadow var(--belki-transition);
 }
 
 .belki-calendar-day:nth-child(7n + 7) {
@@ -3572,7 +3574,7 @@ button.belki-label-actions-button:focus-visible {
 }
 
 .belki-calendar-day.is-selected {
-  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--belki-accent) 28%, transparent);
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--belki-accent) 30%, transparent);
 }
 
 .belki-calendar-day.is-today .belki-calendar-day-number {
@@ -3597,11 +3599,11 @@ button.belki-label-actions-button:focus-visible {
   border-radius: 999px;
   color: inherit;
   display: inline-flex;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 700;
-  height: 24px;
+  height: 26px;
   justify-content: center;
-  min-width: 24px;
+  min-width: 26px;
   padding: 0 6px;
 }
 
@@ -3626,8 +3628,8 @@ button.belki-label-actions-button:focus-visible {
 .belki-calendar-task-chips {
   align-content: start;
   display: grid;
-  gap: 4px;
-  margin-top: 6px;
+  gap: 6px;
+  margin-top: 8px;
   min-width: 0;
 }
 
@@ -3643,13 +3645,13 @@ button.belki-label-actions-button:focus-visible {
   display: -webkit-box;
   font: inherit;
   font-size: 12px;
-  height: 36px;
+  height: 38px;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   line-height: 1.25;
   min-width: 0;
   overflow: hidden;
-  padding: 4px 6px;
+  padding: 5px 7px;
   text-align: left;
   white-space: normal;
 }
@@ -3674,14 +3676,14 @@ button.belki-label-actions-button:focus-visible {
   color: var(--belki-muted);
   font-size: 12px;
   line-height: 1.3;
-  padding: 1px 6px;
+  padding: 0 7px;
 }
 
 .belki-calendar-selected {
-  border-top: 1px solid var(--belki-border);
+  border-top: 1px solid color-mix(in srgb, var(--belki-border) 72%, transparent);
   display: grid;
-  gap: 10px;
-  padding-top: 14px;
+  gap: 12px;
+  padding-top: 16px;
 }
 
 .belki-calendar-selected-header {
@@ -3721,7 +3723,7 @@ button.belki-label-actions-button:focus-visible {
   appearance: none;
   background: transparent;
   border: 0;
-  border-bottom: 1px solid var(--belki-border);
+  border-bottom: 1px solid color-mix(in srgb, var(--belki-border) 72%, transparent);
   border-left: 3px solid transparent;
   border-radius: 0;
   box-shadow: none;
@@ -3729,10 +3731,10 @@ button.belki-label-actions-button:focus-visible {
   cursor: pointer;
   display: grid;
   font: inherit;
-  gap: 10px;
+  gap: 12px;
   grid-template-columns: 68px minmax(0, 1fr);
-  min-height: 46px;
-  padding: 8px 0;
+  min-height: 54px;
+  padding: 10px 0;
   text-align: left;
 }
 
@@ -3775,11 +3777,14 @@ button.belki-label-actions-button:focus-visible {
 
 .belki-calendar-selected-title {
   color: var(--belki-text);
+  display: -webkit-box;
   font-size: 13px;
   font-weight: 600;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-height: 1.3;
+  white-space: normal;
 }
 
 .belki-calendar-selected-meta {

--- a/styles.css
+++ b/styles.css
@@ -3471,6 +3471,391 @@ button.belki-label-actions-button:focus-visible {
   color: var(--belki-muted);
 }
 
+.belki-calendar {
+  display: grid;
+  gap: 18px;
+}
+
+.belki-calendar-toolbar {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 34px minmax(0, 1fr) 34px auto;
+}
+
+.belki-calendar-month-label {
+  color: var(--belki-text);
+  font-size: 16px;
+  font-weight: 700;
+  min-width: 0;
+  text-align: center;
+}
+
+.belki-calendar-nav-button,
+.belki-calendar-today-button {
+  align-items: center;
+  appearance: none;
+  background: var(--belki-hover);
+  border: 0;
+  border-radius: var(--belki-radius);
+  box-shadow: none;
+  color: var(--belki-text);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  justify-content: center;
+  min-height: 34px;
+  padding: 0 10px;
+}
+
+.belki-calendar-nav-button {
+  aspect-ratio: 1;
+  padding: 0;
+}
+
+.belki-calendar-nav-button:hover,
+.belki-calendar-today-button:hover {
+  background: var(--belki-border);
+}
+
+.belki-calendar-grid {
+  border: 1px solid var(--belki-border);
+  border-radius: var(--belki-radius);
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  overflow: hidden;
+}
+
+.belki-calendar-weekday {
+  background: var(--belki-sidebar-bg);
+  border-bottom: 1px solid var(--belki-border);
+  color: var(--belki-muted);
+  font-size: 11px;
+  font-weight: 700;
+  min-width: 0;
+  padding: 8px 6px;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.belki-calendar-day {
+  background: var(--belki-surface);
+  border-bottom: 1px solid var(--belki-border);
+  border-right: 1px solid var(--belki-border);
+  cursor: pointer;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 112px;
+  min-width: 0;
+  padding: 7px;
+  position: relative;
+}
+
+.belki-calendar-day:nth-child(7n + 7) {
+  border-right: 0;
+}
+
+.belki-calendar-day:nth-last-child(-n + 7) {
+  border-bottom: 0;
+}
+
+.belki-calendar-day:hover,
+.belki-calendar-day:focus-visible {
+  background: var(--belki-hover);
+  outline: none;
+}
+
+.belki-calendar-day.is-muted {
+  color: var(--belki-faint);
+}
+
+.belki-calendar-day.is-selected {
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--belki-accent) 28%, transparent);
+}
+
+.belki-calendar-day.is-today .belki-calendar-day-number {
+  background: var(--belki-accent);
+  color: var(--belki-on-accent);
+}
+
+.belki-calendar-day.is-overdue {
+  background: color-mix(in srgb, var(--belki-danger) 5%, var(--belki-surface));
+}
+
+.belki-calendar-day-header {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.belki-calendar-day-number {
+  align-items: center;
+  border-radius: 999px;
+  color: inherit;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 700;
+  height: 24px;
+  justify-content: center;
+  min-width: 24px;
+  padding: 0 6px;
+}
+
+.belki-calendar-deadline-indicator {
+  align-items: center;
+  background: color-mix(in srgb, var(--belki-danger) 10%, transparent);
+  border-radius: 999px;
+  color: var(--belki-danger);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 700;
+  gap: 3px;
+  min-height: 20px;
+  padding: 0 6px;
+}
+
+.belki-calendar-mobile-count {
+  display: none;
+}
+
+.belki-calendar-task-chips {
+  align-content: start;
+  display: grid;
+  gap: 4px;
+  margin-top: 6px;
+  min-width: 0;
+}
+
+.belki-calendar-task-chip {
+  appearance: none;
+  background: var(--belki-chip-bg);
+  border: 1px solid transparent;
+  border-radius: 5px;
+  box-shadow: none;
+  color: var(--belki-text);
+  cursor: pointer;
+  display: block;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.25;
+  min-height: 24px;
+  min-width: 0;
+  overflow: hidden;
+  padding: 4px 6px;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.belki-calendar-task-chip:hover,
+.belki-calendar-task-chip:focus-visible {
+  background: var(--belki-border);
+  outline: none;
+}
+
+.belki-calendar-more {
+  color: var(--belki-muted);
+  font-size: 12px;
+  line-height: 1.3;
+  padding: 1px 6px;
+}
+
+.belki-calendar-selected {
+  border-top: 1px solid var(--belki-border);
+  display: grid;
+  gap: 10px;
+  padding-top: 14px;
+}
+
+.belki-calendar-selected-header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.belki-calendar-selected-header h2 {
+  color: var(--belki-text);
+  font-size: 15px;
+  font-weight: 700;
+  margin: 0;
+  min-width: 0;
+}
+
+.belki-calendar-selected-count {
+  color: var(--belki-muted);
+  flex: 0 0 auto;
+  font-size: 12px;
+}
+
+.belki-calendar-empty {
+  color: var(--belki-muted);
+  font-size: 13px;
+  padding: 6px 0;
+}
+
+.belki-calendar-selected-list {
+  display: grid;
+}
+
+.belki-calendar-selected-task {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--belki-border);
+  border-radius: 0;
+  box-shadow: none;
+  color: var(--belki-text);
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  gap: 10px;
+  grid-template-columns: 74px minmax(0, 1fr);
+  min-height: 46px;
+  padding: 8px 0;
+  text-align: left;
+}
+
+.belki-calendar-selected-task:hover,
+.belki-calendar-selected-task:focus-visible {
+  background: var(--belki-hover);
+  outline: none;
+}
+
+.belki-calendar-selected-role {
+  border: 1px solid var(--belki-border);
+  border-radius: 999px;
+  color: var(--belki-muted);
+  font-size: 11px;
+  font-weight: 700;
+  justify-self: start;
+  padding: 3px 7px;
+  text-transform: uppercase;
+}
+
+.belki-calendar-selected-task.is-deadline .belki-calendar-selected-role {
+  border-color: color-mix(in srgb, var(--belki-danger) 24%, var(--belki-border));
+  color: var(--belki-danger);
+}
+
+.belki-calendar-selected-content {
+  min-width: 0;
+}
+
+.belki-calendar-selected-title {
+  color: var(--belki-text);
+  font-size: 13px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.belki-calendar-selected-meta {
+  color: var(--belki-muted);
+  font-size: 12px;
+  margin-top: 2px;
+  min-height: 15px;
+}
+
+@media (max-width: 720px) {
+  .belki-calendar {
+    gap: 14px;
+  }
+
+  .belki-calendar-toolbar {
+    grid-template-columns: 34px minmax(0, 1fr) 34px;
+  }
+
+  .belki-calendar-today-button {
+    grid-column: 1 / -1;
+    justify-self: stretch;
+  }
+
+  .belki-calendar-weekday {
+    font-size: 10px;
+    padding: 7px 2px;
+  }
+
+  .belki-calendar-day {
+    min-height: 54px;
+    padding: 5px;
+  }
+
+  .belki-calendar-day-number {
+    font-size: 11px;
+    height: 22px;
+    min-width: 22px;
+    padding: 0 5px;
+  }
+
+  .belki-calendar-deadline-indicator {
+    font-size: 0;
+    gap: 0;
+    min-height: 8px;
+    min-width: 8px;
+    padding: 0;
+  }
+
+  .belki-calendar-deadline-indicator .belki-icon {
+    display: none;
+  }
+
+  .belki-calendar-task-chips {
+    display: none;
+  }
+
+  .belki-calendar-mobile-count {
+    align-self: end;
+    background: var(--belki-chip-bg);
+    border-radius: 999px;
+    color: var(--belki-muted);
+    display: inline-flex;
+    font-size: 11px;
+    font-weight: 700;
+    justify-content: center;
+    justify-self: start;
+    line-height: 1;
+    min-width: 18px;
+    padding: 4px 6px;
+  }
+
+  .belki-calendar-selected-task {
+    grid-template-columns: 68px minmax(0, 1fr);
+  }
+}
+
+.belki-root.is-mobile .belki-calendar-task-chips {
+  display: none;
+}
+
+.belki-root.is-mobile .belki-calendar-day {
+  min-height: 54px;
+  padding: 5px;
+}
+
+.belki-root.is-mobile .belki-calendar-mobile-count {
+  align-self: end;
+  background: var(--belki-chip-bg);
+  border-radius: 999px;
+  color: var(--belki-muted);
+  display: inline-flex;
+  font-size: 11px;
+  font-weight: 700;
+  justify-content: center;
+  justify-self: start;
+  line-height: 1;
+  min-width: 18px;
+  padding: 4px 6px;
+}
+
 .belki-search-backdrop {
   align-items: flex-start;
   backdrop-filter: blur(2px);

--- a/tests/calendarModel.test.ts
+++ b/tests/calendarModel.test.ts
@@ -1,0 +1,154 @@
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import type { BelkiTask } from "../src/types";
+import {
+  buildCalendarTaskGroups,
+  buildMonthGrid,
+  getCalendarTasksForDate,
+  hasCalendarDate
+} from "../src/views/calendar/calendarModel";
+import {
+  addCalendarMonths,
+  selectedDateForCalendarMonth
+} from "../src/views/calendar/calendarUtils";
+
+test("buildMonthGrid creates a 42-day month grid with leading and trailing days", () => {
+  const groups = buildCalendarTaskGroups([]);
+  const days = buildMonthGrid({
+    month: { year: 2026, month: 4 },
+    taskGroups: groups,
+    today: "2026-05-15"
+  });
+
+  assert.equal(days.length, 42);
+  assert.equal(days[0].date, "2026-04-27");
+  assert.equal(days[0].isCurrentMonth, false);
+  assert.equal(days[4].date, "2026-05-01");
+  assert.equal(days[4].isCurrentMonth, true);
+  assert.equal(days[41].date, "2026-06-07");
+  assert.equal(days[41].isCurrentMonth, false);
+});
+
+test("buildMonthGrid marks today and selected dates", () => {
+  const groups = buildCalendarTaskGroups([]);
+  const days = buildMonthGrid({
+    month: { year: 2026, month: 6 },
+    taskGroups: groups,
+    today: "2026-07-13",
+    selectedDate: "2026-07-20"
+  });
+
+  assert.equal(days.find((day) => day.date === "2026-07-13")?.isToday, true);
+  assert.equal(days.find((day) => day.date === "2026-07-20")?.isSelected, true);
+});
+
+test("buildCalendarTaskGroups groups tasks by due date and deadline indicators", () => {
+  const dueOnly = createTask("due-only", { due: "2026-07-15" });
+  const dueAndDeadline = createTask("due-and-deadline", {
+    due: "2026-07-15",
+    deadline: "2026-07-20",
+    order: 1
+  });
+  const deadlineOnly = createTask("deadline-only", {
+    deadline: "2026-07-20",
+    order: 2
+  });
+
+  const groups = buildCalendarTaskGroups([dueOnly, dueAndDeadline, deadlineOnly]);
+
+  assert.deepEqual(
+    groups.dueTasksByDate.get("2026-07-15")?.map((task) => task.id),
+    ["due-only", "due-and-deadline"]
+  );
+  assert.deepEqual(
+    groups.deadlineTasksByDate.get("2026-07-20")?.map((task) => task.id),
+    ["due-and-deadline", "deadline-only"]
+  );
+});
+
+test("buildMonthGrid exposes deadline counts separately from due chips", () => {
+  const groups = buildCalendarTaskGroups([
+    createTask("task", { due: "2026-07-15", deadline: "2026-07-20" })
+  ]);
+  const days = buildMonthGrid({
+    month: { year: 2026, month: 6 },
+    taskGroups: groups,
+    today: "2026-07-01"
+  });
+
+  const dueDay = days.find((day) => day.date === "2026-07-15");
+  const deadlineDay = days.find((day) => day.date === "2026-07-20");
+  assert.equal(dueDay?.dueTasks.length, 1);
+  assert.equal(dueDay?.deadlineCount, 0);
+  assert.equal(deadlineDay?.dueTasks.length, 0);
+  assert.equal(deadlineDay?.deadlineCount, 1);
+});
+
+test("tasks without a valid date are skipped", () => {
+  const noDate = createTask("no-date");
+  const invalidDate = createTask("invalid-date", { due: "2026-02-31" });
+  const groups = buildCalendarTaskGroups([noDate, invalidDate]);
+
+  assert.equal(hasCalendarDate(noDate), false);
+  assert.equal(hasCalendarDate(invalidDate), false);
+  assert.equal(groups.dueTasksByDate.size, 0);
+  assert.equal(groups.deadlineTasksByDate.size, 0);
+});
+
+test("getCalendarTasksForDate returns due entries before deadline entries", () => {
+  const due = createTask("due", { due: "2026-07-13" });
+  const deadline = createTask("deadline", { deadline: "2026-07-13", order: 1 });
+  const groups = buildCalendarTaskGroups([deadline, due]);
+
+  assert.deepEqual(
+    getCalendarTasksForDate(groups, "2026-07-13").map((entry) => `${entry.role}:${entry.task.id}`),
+    ["due:due", "deadline:deadline"]
+  );
+});
+
+test("buildMonthGrid marks overdue days with open due tasks", () => {
+  const groups = buildCalendarTaskGroups([
+    createTask("open", { due: "2026-07-01" }),
+    createTask("done", { due: "2026-07-02", completed: true })
+  ]);
+  const days = buildMonthGrid({
+    month: { year: 2026, month: 6 },
+    taskGroups: groups,
+    today: "2026-07-13"
+  });
+
+  assert.equal(days.find((day) => day.date === "2026-07-01")?.isOverdue, true);
+  assert.equal(days.find((day) => day.date === "2026-07-02")?.isOverdue, false);
+});
+
+test("addCalendarMonths handles December to January and January to December", () => {
+  assert.deepEqual(addCalendarMonths({ year: 2026, month: 11 }, 1), {
+    year: 2027,
+    month: 0
+  });
+  assert.deepEqual(addCalendarMonths({ year: 2026, month: 0 }, -1), {
+    year: 2025,
+    month: 11
+  });
+});
+
+test("selectedDateForCalendarMonth clamps long months to shorter months", () => {
+  assert.equal(
+    selectedDateForCalendarMonth({ year: 2026, month: 1 }, "2026-01-31"),
+    "2026-02-28"
+  );
+});
+
+function createTask(id: string, overrides: Partial<BelkiTask> = {}): BelkiTask {
+  return {
+    id,
+    title: id,
+    completed: false,
+    priority: "none",
+    labels: [],
+    attachments: [],
+    extraProperties: [],
+    order: 0,
+    ...overrides
+  };
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "tmp/test-dist",
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/dateUtils.ts",
+    "src/types.ts",
+    "src/views/calendar/**/*.ts",
+    "tests/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Implements issue #32 with a lightweight monthly Calendar view for Belki Tasks.

- Adds a new Calendar navigation entry without replacing existing task-focused views.
- Renders a monthly grid with previous/next/Today controls, adjacent-month days, today/selected/overdue states, due task chips, and deadline indicators.
- Uses existing active task visibility and existing TaskDetailModal behavior when opening tasks from the calendar.
- Adds pure calendar date/model helpers plus unit tests for grid generation, leading/trailing days, today detection, due/deadline grouping, no-date tasks, overdue marking, and month navigation edge cases.

## Safety

- No task storage format changes.
- No TaskStore/parser/serializer changes.
- No drag and drop or external calendar integrations.

## Validation

- `pnpm run test`
- `pnpm run build`

Closes #32