### PR TITLE
feat: add bulk overdue rescheduling

### DIFF
--- a/main.js
+++ b/main.js
@@ -2565,6 +2565,70 @@ function legacyBackupPathCandidate(path, index) {
   return index <= 1 ? `${base}.migrated-backup.md` : `${base}.migrated-backup-${index}.md`;
 }
 
+// src/taskBulkActions.ts
+function getOverdueRangeDates(today = todayIso()) {
+  return {
+    today,
+    yesterday: addDaysToIsoDate2(today, -1),
+    last7Start: addDaysToIsoDate2(today, -7),
+    last30Start: addDaysToIsoDate2(today, -30)
+  };
+}
+function getVisibleOverdueTasksForBulkReschedule(tasks, range, dates = getOverdueRangeDates()) {
+  return tasks.filter((task) => isVisibleOverdueTaskForRange(task, range, dates));
+}
+function isVisibleOverdueTaskForRange(task, range, dates = getOverdueRangeDates()) {
+  if (task.completed || task.parentId || !task.due || task.due >= dates.today) {
+    return false;
+  }
+  if (range === "yesterday") {
+    return task.due === dates.yesterday;
+  }
+  if (range === "last7") {
+    return task.due >= dates.last7Start;
+  }
+  if (range === "last30") {
+    return task.due >= dates.last30Start;
+  }
+  return task.due < dates.last30Start;
+}
+function dueDateForBulkRescheduleShortcut(shortcut) {
+  if (shortcut === "today") {
+    return todayIso();
+  }
+  if (shortcut === "tomorrow") {
+    return addDaysIso(1);
+  }
+  return addDaysIso(7);
+}
+function createTaskDueDateUpdatePlan(tasks, taskIds, due) {
+  const idSet = new Set(taskIds);
+  const changedIds = [];
+  const nextTasks = tasks.map((task) => {
+    if (!idSet.has(task.id) || task.due === due) {
+      return task;
+    }
+    changedIds.push(task.id);
+    return {
+      ...task,
+      due
+    };
+  });
+  return {
+    tasks: nextTasks,
+    changedIds
+  };
+}
+function addDaysToIsoDate2(value, days) {
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  date.setDate(date.getDate() + days);
+  const nextYear = date.getFullYear();
+  const nextMonth = String(date.getMonth() + 1).padStart(2, "0");
+  const nextDay = String(date.getDate()).padStart(2, "0");
+  return `${nextYear}-${nextMonth}-${nextDay}`;
+}
+
 // src/taskStore.ts
 var TaskStore = class {
   constructor(app, settings) {
@@ -2733,6 +2797,32 @@ var TaskStore = class {
     });
     await this.saveSources([sourcePath]);
   }
+  async updateTaskDueDates(taskIds, due) {
+    const normalizedDue = normalizeOptional(due);
+    if (!normalizedDue || taskIds.length === 0) {
+      return;
+    }
+    const previousTasks = this.tasks;
+    const previousDocuments = new Map(this.documents);
+    const plan = createTaskDueDateUpdatePlan(this.tasks, taskIds, normalizedDue);
+    if (plan.changedIds.length === 0) {
+      return;
+    }
+    const changedSources = /* @__PURE__ */ new Set();
+    for (const task of plan.tasks) {
+      if (plan.changedIds.includes(task.id)) {
+        changedSources.add(task.sourcePath || this.monthlyPathForDate(task.created || todayIso()));
+      }
+    }
+    this.tasks = plan.tasks;
+    try {
+      await this.saveBulkSources([...changedSources], previousTasks, previousDocuments);
+    } catch (error) {
+      this.tasks = previousTasks;
+      this.documents = previousDocuments;
+      throw error;
+    }
+  }
   async toggleComplete(id) {
     const task = this.tasks.find((candidate) => candidate.id === id);
     if (!task) {
@@ -2878,15 +2968,8 @@ var TaskStore = class {
   }
   async rescheduleOverdueToToday() {
     const today = todayIso();
-    const changedSources = /* @__PURE__ */ new Set();
-    this.tasks = this.tasks.map((task) => {
-      if (!task.completed && task.due && task.due < today) {
-        changedSources.add(task.sourcePath || this.monthlyPathForDate(task.created || today));
-        return { ...task, due: today };
-      }
-      return task;
-    });
-    await this.saveSources([...changedSources]);
+    const taskIds = this.tasks.filter((task) => !task.completed && task.due && task.due < today).map((task) => task.id);
+    await this.updateTaskDueDates(taskIds, today);
   }
   async normalizeLabels() {
     const changedSources = /* @__PURE__ */ new Set();
@@ -2980,6 +3063,37 @@ var TaskStore = class {
   async saveSources(sourcePaths) {
     await this.writeSources(sourcePaths);
     await this.load();
+  }
+  async saveBulkSources(sourcePaths, previousTasks, previousDocuments) {
+    const rollbackContents = /* @__PURE__ */ new Map();
+    for (const sourcePath of dedupeStrings(sourcePaths.filter(Boolean))) {
+      const document2 = previousDocuments.get(sourcePath) || { blocks: [], tasks: [] };
+      const tasks = previousTasks.filter((task) => task.sourcePath === sourcePath).map((task) => normalizeTaskForSave(task, sourcePath));
+      rollbackContents.set(sourcePath, serializeTaskDocument(document2, tasks));
+    }
+    try {
+      await this.saveSources(sourcePaths);
+    } catch (error) {
+      await this.rollbackSourceContents(rollbackContents);
+      throw error;
+    }
+  }
+  async rollbackSourceContents(contents) {
+    for (const [sourcePath, content] of contents) {
+      const file = await this.ensureFile(sourcePath, "");
+      if (!file) {
+        continue;
+      }
+      this.writingPaths.add((0, import_obsidian8.normalizePath)(sourcePath));
+      try {
+        await this.app.vault.modify(file, content);
+        this.documents.set(sourcePath, parseTaskDocument(content, sourcePath));
+      } catch (rollbackError) {
+        console.warn("[belki] Failed to roll back task source after bulk update failure.", rollbackError);
+      } finally {
+        this.writingPaths.delete((0, import_obsidian8.normalizePath)(sourcePath));
+      }
+    }
   }
   async writeSources(sourcePaths) {
     for (const sourcePath of dedupeStrings(sourcePaths.filter(Boolean))) {
@@ -5351,6 +5465,97 @@ var ImagePreviewModal = class extends import_obsidian13.Modal {
   }
 };
 
+// src/views/datePicker.ts
+function renderCustomDatePicker(parent, currentValue, onSelect, options = {}) {
+  const todayStr = todayIso();
+  const initDate = currentValue ? /* @__PURE__ */ new Date(currentValue + "T00:00:00") : /* @__PURE__ */ new Date();
+  let viewYear = initDate.getFullYear();
+  let viewMonth = initDate.getMonth();
+  const container = parent.createDiv({ cls: "belki-date-custom-wrap" });
+  const trigger = container.createEl("button", {
+    cls: "belki-date-preset belki-cal-trigger",
+    attr: {
+      type: "button",
+      ...options.triggerRole ? { role: options.triggerRole } : {},
+      ...options.triggerAriaLabel ? { "aria-label": options.triggerAriaLabel } : {}
+    }
+  });
+  trigger.createSpan({
+    text: currentValue ? formatDueDateChip(currentValue) : options.triggerLabel || "Custom date\u2026"
+  });
+  if (currentValue) trigger.addClass("is-active");
+  const calWrap = container.createDiv({ cls: "belki-cal-wrap is-hidden" });
+  function renderCal() {
+    calWrap.empty();
+    const header = calWrap.createDiv({ cls: "belki-cal-header" });
+    const prevBtn = header.createEl("button", { cls: "belki-cal-nav", attr: { type: "button" } });
+    prevBtn.setText("\u2039");
+    header.createSpan({
+      cls: "belki-cal-title",
+      text: new Date(viewYear, viewMonth, 1).toLocaleDateString(void 0, { month: "long", year: "numeric" })
+    });
+    const nextBtn = header.createEl("button", { cls: "belki-cal-nav", attr: { type: "button" } });
+    nextBtn.setText("\u203A");
+    prevBtn.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      prevBtn.blur();
+      if (--viewMonth < 0) {
+        viewMonth = 11;
+        viewYear--;
+      }
+      renderCal();
+    });
+    nextBtn.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      nextBtn.blur();
+      if (++viewMonth > 11) {
+        viewMonth = 0;
+        viewYear++;
+      }
+      renderCal();
+    });
+    const grid = calWrap.createDiv({ cls: "belki-cal-grid" });
+    for (const d of ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]) {
+      grid.createSpan({ cls: "belki-cal-day-hdr", text: d });
+    }
+    const firstDow = new Date(viewYear, viewMonth, 1).getDay();
+    const leadingEmpties = firstDow === 0 ? 6 : firstDow - 1;
+    for (let i = 0; i < leadingEmpties; i++) {
+      grid.createDiv({ cls: "belki-cal-day is-empty" });
+    }
+    const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+    for (let d = 1; d <= daysInMonth; d++) {
+      const iso = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+      const cell = grid.createEl("button", {
+        cls: "belki-cal-day",
+        text: String(d),
+        attr: { type: "button" }
+      });
+      if (iso === todayStr) cell.addClass("is-today");
+      if (iso === currentValue) cell.addClass("is-selected");
+      cell.addEventListener("click", (e) => {
+        e.stopPropagation();
+        onSelect(iso);
+      });
+    }
+    const renderedCells = leadingEmpties + daysInMonth;
+    const trailingEmpties = 42 - renderedCells;
+    for (let i = 0; i < trailingEmpties; i++) {
+      grid.createDiv({ cls: "belki-cal-day is-empty" });
+    }
+  }
+  trigger.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const opening = calWrap.hasClass("is-hidden");
+    parent.toggleClass("is-calendar-open", opening);
+    calWrap.toggleClass("is-hidden", !opening);
+    if (opening) renderCal();
+  });
+}
+
 // src/views/task-detail/dateRepeatFields.ts
 function renderTaskDetailDateRepeatFields(parent, options) {
   renderDueDatePicker(parent, options);
@@ -5413,7 +5618,7 @@ function renderDueDatePicker(parent, options) {
     addPreset("Next week", addDaysIso(7));
     addPreset("Next weekend", nextWeekdayIso(6));
     popover.createDiv({ cls: "belki-date-divider" });
-    renderCustomDatePicker(popover, state.due, "calendar", selectDate);
+    renderCustomDatePicker(popover, state.due, selectDate);
     popover.createDiv({ cls: "belki-date-divider" });
     const repeatHeader = popover.createDiv({ cls: "belki-repeat-header" });
     createBelkiIcon(repeatHeader, "recurring", { className: "belki-chip-icon" });
@@ -5559,7 +5764,7 @@ function renderDeadlinePicker(parent, options) {
     addPreset("Tomorrow", addDaysIso(1));
     addPreset("Next week", addDaysIso(7));
     addPreset("Next weekend", nextWeekdayIso(6));
-    renderCustomDatePicker(popover, state.deadline, "deadline", selectDate);
+    renderCustomDatePicker(popover, state.deadline, selectDate);
     btn.addEventListener("click", () => {
       const isHidden = popover.hasClass("is-hidden");
       closePopover();
@@ -5578,89 +5783,6 @@ function createField(parent, label) {
   const field = parent.createDiv({ cls: "belki-detail-field" });
   field.createDiv({ cls: "belki-detail-label", text: label });
   return field;
-}
-function renderCustomDatePicker(parent, currentValue, _iconName, onSelect) {
-  const todayStr = todayIso();
-  const initDate = currentValue ? /* @__PURE__ */ new Date(currentValue + "T00:00:00") : /* @__PURE__ */ new Date();
-  let viewYear = initDate.getFullYear();
-  let viewMonth = initDate.getMonth();
-  const container = parent.createDiv({ cls: "belki-date-custom-wrap" });
-  const trigger = container.createEl("button", {
-    cls: "belki-date-preset belki-cal-trigger",
-    attr: { type: "button" }
-  });
-  trigger.createSpan({ text: currentValue ? formatDueDateChip(currentValue) : "Custom date\u2026" });
-  if (currentValue) trigger.addClass("is-active");
-  const calWrap = container.createDiv({ cls: "belki-cal-wrap is-hidden" });
-  function renderCal() {
-    calWrap.empty();
-    const header = calWrap.createDiv({ cls: "belki-cal-header" });
-    const prevBtn = header.createEl("button", { cls: "belki-cal-nav", attr: { type: "button" } });
-    prevBtn.setText("\u2039");
-    header.createSpan({
-      cls: "belki-cal-title",
-      text: new Date(viewYear, viewMonth, 1).toLocaleDateString(void 0, { month: "long", year: "numeric" })
-    });
-    const nextBtn = header.createEl("button", { cls: "belki-cal-nav", attr: { type: "button" } });
-    nextBtn.setText("\u203A");
-    prevBtn.addEventListener("click", (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      prevBtn.blur();
-      if (--viewMonth < 0) {
-        viewMonth = 11;
-        viewYear--;
-      }
-      renderCal();
-    });
-    nextBtn.addEventListener("click", (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      nextBtn.blur();
-      if (++viewMonth > 11) {
-        viewMonth = 0;
-        viewYear++;
-      }
-      renderCal();
-    });
-    const grid = calWrap.createDiv({ cls: "belki-cal-grid" });
-    for (const d of ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]) {
-      grid.createSpan({ cls: "belki-cal-day-hdr", text: d });
-    }
-    const firstDow = new Date(viewYear, viewMonth, 1).getDay();
-    const leadingEmpties = firstDow === 0 ? 6 : firstDow - 1;
-    for (let i = 0; i < leadingEmpties; i++) {
-      grid.createDiv({ cls: "belki-cal-day is-empty" });
-    }
-    const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
-    for (let d = 1; d <= daysInMonth; d++) {
-      const iso = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
-      const cell = grid.createEl("button", {
-        cls: "belki-cal-day",
-        text: String(d),
-        attr: { type: "button" }
-      });
-      if (iso === todayStr) cell.addClass("is-today");
-      if (iso === currentValue) cell.addClass("is-selected");
-      cell.addEventListener("click", (e) => {
-        e.stopPropagation();
-        onSelect(iso);
-      });
-    }
-    const renderedCells = leadingEmpties + daysInMonth;
-    const trailingEmpties = 42 - renderedCells;
-    for (let i = 0; i < trailingEmpties; i++) {
-      grid.createDiv({ cls: "belki-cal-day is-empty" });
-    }
-  }
-  trigger.addEventListener("click", (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    const opening = calWrap.hasClass("is-hidden");
-    parent.toggleClass("is-calendar-open", opening);
-    calWrap.toggleClass("is-hidden", !opening);
-    if (opening) renderCal();
-  });
 }
 
 // src/views/task-detail/descriptionFormatting.ts
@@ -7896,6 +8018,97 @@ function createTaskActionMenuButton(parent, label, onClick) {
   });
 }
 
+// src/views/tasks/BulkReschedulePopover.ts
+function renderBulkReschedulePopover(options) {
+  const wrapper = options.parent.createDiv({ cls: "belki-bulk-reschedule" });
+  const button = wrapper.createEl("button", {
+    cls: "belki-reschedule",
+    text: `Reschedule ${options.count}`,
+    attr: {
+      type: "button",
+      "aria-haspopup": "menu",
+      "aria-expanded": "false",
+      "aria-label": `Reschedule ${options.count} overdue task${options.count === 1 ? "" : "s"}`
+    }
+  });
+  let popover = null;
+  let detachOutside = null;
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (popover) {
+      closePopover(true);
+    } else {
+      openPopover();
+    }
+  });
+  const openPopover = () => {
+    closePopover(false);
+    button.setAttr("aria-expanded", "true");
+    popover = wrapper.createDiv({
+      cls: "belki-bulk-reschedule-popover",
+      attr: { role: "menu", "aria-label": "Reschedule overdue tasks" }
+    });
+    popover.addEventListener("click", (event) => event.stopPropagation());
+    popover.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        closePopover(true);
+      }
+    });
+    popover.createDiv({
+      cls: "belki-bulk-reschedule-title",
+      text: `Reschedule ${options.count} task${options.count === 1 ? "" : "s"}`
+    });
+    createPresetButton(popover, "Today", dueDateForBulkRescheduleShortcut("today"), selectDue);
+    createPresetButton(popover, "Tomorrow", dueDateForBulkRescheduleShortcut("tomorrow"), selectDue);
+    createPresetButton(popover, "Next week", dueDateForBulkRescheduleShortcut("nextWeek"), selectDue);
+    popover.createDiv({ cls: "belki-date-divider" });
+    renderCustomDatePicker(popover, void 0, (value) => {
+      selectDue(value, value);
+    }, {
+      triggerLabel: "Pick a date...",
+      triggerAriaLabel: "Pick bulk reschedule date",
+      triggerRole: "menuitem"
+    });
+    const ownerDocument = wrapper.ownerDocument;
+    const handleOutside = (event) => {
+      if (!wrapper.contains(event.target)) {
+        closePopover(false);
+      }
+    };
+    ownerDocument.addEventListener("click", handleOutside, { capture: true });
+    detachOutside = () => ownerDocument.removeEventListener("click", handleOutside, { capture: true });
+  };
+  const closePopover = (restoreFocus) => {
+    popover == null ? void 0 : popover.remove();
+    popover = null;
+    button.setAttr("aria-expanded", "false");
+    detachOutside == null ? void 0 : detachOutside();
+    detachOutside = null;
+    if (restoreFocus) {
+      button.focus();
+    }
+  };
+  const selectDue = (due, label) => {
+    closePopover(false);
+    options.onSelectDue(due, label);
+  };
+  return () => closePopover(false);
+}
+function createPresetButton(parent, label, due, onSelectDue) {
+  parent.createEl("button", {
+    cls: "belki-bulk-reschedule-option",
+    text: label,
+    attr: { type: "button", role: "menuitem" }
+  }).addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onSelectDue(due, label);
+  });
+}
+
 // src/calendar/calendarGrouping.ts
 function groupVisibleCalendarEvents(events) {
   return groupCalendarEventsByDate(events);
@@ -8114,6 +8327,7 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
     this.pendingScrollSnapshot = null;
     this.mobileComposerReturnScroll = null;
     this.composerCleanup = null;
+    this.bulkRescheduleCleanup = null;
     this.renderScheduled = false;
     this.calendarRangeRequestKey = null;
     this.handleRootClick = (event) => {
@@ -8306,14 +8520,16 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
     return this.mode === "daily-note";
   }
   render() {
-    var _a, _b, _c;
+    var _a, _b, _c, _d;
     (_a = this.composerCleanup) == null ? void 0 : _a.call(this);
     this.composerCleanup = null;
+    (_b = this.bulkRescheduleCleanup) == null ? void 0 : _b.call(this);
+    this.bulkRescheduleCleanup = null;
     this.removeProjectMenu();
     this.removeLabelMenu();
     this.removeTaskActionMenu();
     const { containerEl } = this;
-    const sidebarScrollLeft = (_c = (_b = containerEl.querySelector(".belki-sidebar")) == null ? void 0 : _b.scrollLeft) != null ? _c : this.sidebarScrollLeft;
+    const sidebarScrollLeft = (_d = (_c = containerEl.querySelector(".belki-sidebar")) == null ? void 0 : _c.scrollLeft) != null ? _d : this.sidebarScrollLeft;
     containerEl.empty();
     containerEl.addClass("belki-root");
     containerEl.addClass("belki-view");
@@ -8884,6 +9100,7 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
       if (hasAnyOverdue) {
         const section2 = this.createSection(parent, "Overdue", overdue.length, (header) => {
           this.renderOverdueRangeSelect(header);
+          this.renderBulkRescheduleAction(header, overdue);
         });
         this.renderTaskList(section2, overdue);
       }
@@ -9398,6 +9615,33 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
         this.renderPreservingMainScroll();
       })();
     });
+  }
+  renderBulkRescheduleAction(parent, visibleOverdueTasks) {
+    if (visibleOverdueTasks.length === 0) {
+      return;
+    }
+    this.bulkRescheduleCleanup = renderBulkReschedulePopover({
+      parent,
+      count: visibleOverdueTasks.length,
+      onSelectDue: (due, label) => {
+        void this.bulkRescheduleVisibleOverdueTasks(visibleOverdueTasks, due, label);
+      }
+    });
+  }
+  async bulkRescheduleVisibleOverdueTasks(visibleOverdueTasks, due, label) {
+    const taskIds = visibleOverdueTasks.map((task) => task.id);
+    if (taskIds.length === 0) {
+      this.renderPreservingMainScroll();
+      return;
+    }
+    try {
+      await this.store.updateTaskDueDates(taskIds, due);
+      new import_obsidian16.Notice(`${taskIds.length} task${taskIds.length === 1 ? "" : "s"} rescheduled to ${label}.`);
+      this.renderPreservingMainScroll();
+    } catch (error) {
+      console.warn("[belki] Failed to bulk reschedule overdue tasks.", error);
+      new import_obsidian16.Notice("belki could not reschedule those tasks. Please try again.");
+    }
   }
   enableTodayDrop(section) {
     section.addClass("belki-drop-zone");
@@ -9976,7 +10220,10 @@ var TaskBoardView = class extends import_obsidian16.ItemView {
     });
   }
   getOverdueTasks(tasks) {
-    return tasks.filter((task) => this.isInSelectedOverdueRange(task));
+    return getVisibleOverdueTasksForBulkReschedule(
+      tasks,
+      this.settings.defaultOverdueRange
+    );
   }
   isInSelectedOverdueRange(task) {
     if (task.completed || !task.due || task.due >= todayIso()) {

--- a/src/styles/03-task-list.css
+++ b/src/styles/03-task-list.css
@@ -259,18 +259,91 @@
   color: var(--belki-text);
 }
 
-.belki-reschedule {
-  background: transparent;
-  border-radius: 6px;
-  color: var(--belki-accent);
-  font-size: 13px;
-  font-weight: 600;
-  margin-left: auto;
-  padding: 5px 8px;
+.belki-bulk-reschedule {
+  flex: 0 0 auto;
+  position: relative;
 }
 
-.belki-reschedule:hover {
+.belki-reschedule {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  box-shadow: none;
+  color: var(--belki-muted);
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 600;
+  height: 28px;
+  justify-content: center;
+  padding: 0 8px;
+  white-space: nowrap;
+}
+
+.belki-reschedule:hover,
+.belki-reschedule:focus-visible,
+.belki-reschedule[aria-expanded="true"] {
   background: var(--belki-hover);
+  color: var(--belki-text);
+}
+
+.belki-reschedule:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--belki-accent) 52%, transparent);
+  outline-offset: 2px;
+}
+
+.belki-bulk-reschedule-popover {
+  background: var(--belki-surface);
+  border: 1px solid var(--belki-border);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.14);
+  display: grid;
+  gap: 2px;
+  min-width: 190px;
+  padding: 6px;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  z-index: 90;
+}
+
+.belki-bulk-reschedule-popover.is-calendar-open {
+  min-width: min(280px, calc(100vw - 28px));
+}
+
+.belki-bulk-reschedule-title {
+  color: var(--belki-muted);
+  font-size: 12px;
+  font-weight: 700;
+  padding: 6px 8px 4px;
+}
+
+.belki-bulk-reschedule-option {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  box-shadow: none;
+  color: var(--belki-text);
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  font-size: 13px;
+  justify-content: space-between;
+  min-height: 32px;
+  padding: 0 8px;
+  text-align: left;
+}
+
+.belki-bulk-reschedule-option:hover,
+.belki-bulk-reschedule-option:focus-visible {
+  background: var(--belki-hover);
+}
+
+.belki-bulk-reschedule-option:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--belki-accent) 52%, transparent);
+  outline-offset: 2px;
 }
 
 .belki-task-list {

--- a/src/styles/11-mobile.css
+++ b/src/styles/11-mobile.css
@@ -390,6 +390,12 @@
     min-height: 36px;
   }
 
+  .belki-bulk-reschedule-popover {
+    min-width: min(190px, calc(100vw - 28px));
+    right: 0;
+    top: calc(100% + 6px);
+  }
+
   .belki-task-row {
     gap: 10px;
     grid-template-columns: 24px minmax(0, 1fr) 28px;

--- a/src/taskBulkActions.ts
+++ b/src/taskBulkActions.ts
@@ -1,0 +1,104 @@
+import { addDaysIso, todayIso } from "./dateUtils";
+import type { BelkiTask, OverdueRange } from "./types";
+
+export type BulkRescheduleShortcut = "today" | "tomorrow" | "nextWeek";
+
+export interface OverdueRangeDates {
+  today: string;
+  yesterday: string;
+  last7Start: string;
+  last30Start: string;
+}
+
+export interface TaskDueDateUpdatePlan {
+  tasks: BelkiTask[];
+  changedIds: string[];
+}
+
+export function getOverdueRangeDates(today = todayIso()): OverdueRangeDates {
+  return {
+    today,
+    yesterday: addDaysToIsoDate(today, -1),
+    last7Start: addDaysToIsoDate(today, -7),
+    last30Start: addDaysToIsoDate(today, -30)
+  };
+}
+
+export function getVisibleOverdueTasksForBulkReschedule(
+  tasks: BelkiTask[],
+  range: OverdueRange,
+  dates: OverdueRangeDates = getOverdueRangeDates()
+): BelkiTask[] {
+  return tasks.filter((task) => isVisibleOverdueTaskForRange(task, range, dates));
+}
+
+export function isVisibleOverdueTaskForRange(
+  task: BelkiTask,
+  range: OverdueRange,
+  dates: OverdueRangeDates = getOverdueRangeDates()
+): boolean {
+  if (task.completed || task.parentId || !task.due || task.due >= dates.today) {
+    return false;
+  }
+
+  if (range === "yesterday") {
+    return task.due === dates.yesterday;
+  }
+
+  if (range === "last7") {
+    return task.due >= dates.last7Start;
+  }
+
+  if (range === "last30") {
+    return task.due >= dates.last30Start;
+  }
+
+  return task.due < dates.last30Start;
+}
+
+export function dueDateForBulkRescheduleShortcut(shortcut: BulkRescheduleShortcut): string {
+  if (shortcut === "today") {
+    return todayIso();
+  }
+
+  if (shortcut === "tomorrow") {
+    return addDaysIso(1);
+  }
+
+  return addDaysIso(7);
+}
+
+export function createTaskDueDateUpdatePlan(
+  tasks: BelkiTask[],
+  taskIds: string[],
+  due: string
+): TaskDueDateUpdatePlan {
+  const idSet = new Set(taskIds);
+  const changedIds: string[] = [];
+  const nextTasks = tasks.map((task) => {
+    if (!idSet.has(task.id) || task.due === due) {
+      return task;
+    }
+
+    changedIds.push(task.id);
+    return {
+      ...task,
+      due
+    };
+  });
+
+  return {
+    tasks: nextTasks,
+    changedIds
+  };
+}
+
+function addDaysToIsoDate(value: string, days: number): string {
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  date.setDate(date.getDate() + days);
+  const nextYear = date.getFullYear();
+  const nextMonth = String(date.getMonth() + 1).padStart(2, "0");
+  const nextDay = String(date.getDate()).padStart(2, "0");
+  return `${nextYear}-${nextMonth}-${nextDay}`;
+}

--- a/src/taskStore.ts
+++ b/src/taskStore.ts
@@ -24,6 +24,7 @@ import {
   monthlyDataFilePath,
   taskAttachmentFolderPath
 } from "./storage/storagePaths";
+import { createTaskDueDateUpdatePlan } from "./taskBulkActions";
 
 type Listener = () => void;
 
@@ -237,6 +238,36 @@ export class TaskStore {
     await this.saveSources([sourcePath]);
   }
 
+  async updateTaskDueDates(taskIds: string[], due: string): Promise<void> {
+    const normalizedDue = normalizeOptional(due);
+    if (!normalizedDue || taskIds.length === 0) {
+      return;
+    }
+
+    const previousTasks = this.tasks;
+    const previousDocuments = new Map(this.documents);
+    const plan = createTaskDueDateUpdatePlan(this.tasks, taskIds, normalizedDue);
+    if (plan.changedIds.length === 0) {
+      return;
+    }
+
+    const changedSources = new Set<string>();
+    for (const task of plan.tasks) {
+      if (plan.changedIds.includes(task.id)) {
+        changedSources.add(task.sourcePath || this.monthlyPathForDate(task.created || todayIso()));
+      }
+    }
+
+    this.tasks = plan.tasks;
+    try {
+      await this.saveBulkSources([...changedSources], previousTasks, previousDocuments);
+    } catch (error) {
+      this.tasks = previousTasks;
+      this.documents = previousDocuments;
+      throw error;
+    }
+  }
+
   async toggleComplete(id: string): Promise<void> {
     const task = this.tasks.find((candidate) => candidate.id === id);
     if (!task) {
@@ -421,18 +452,10 @@ export class TaskStore {
 
   async rescheduleOverdueToToday(): Promise<void> {
     const today = todayIso();
-    const changedSources = new Set<string>();
-
-    this.tasks = this.tasks.map((task) => {
-      if (!task.completed && task.due && task.due < today) {
-        changedSources.add(task.sourcePath || this.monthlyPathForDate(task.created || today));
-        return { ...task, due: today };
-      }
-
-      return task;
-    });
-
-    await this.saveSources([...changedSources]);
+    const taskIds = this.tasks
+      .filter((task) => !task.completed && task.due && task.due < today)
+      .map((task) => task.id);
+    await this.updateTaskDueDates(taskIds, today);
   }
 
   async normalizeLabels(): Promise<void> {
@@ -549,6 +572,47 @@ export class TaskStore {
   private async saveSources(sourcePaths: string[]): Promise<void> {
     await this.writeSources(sourcePaths);
     await this.load();
+  }
+
+  private async saveBulkSources(
+    sourcePaths: string[],
+    previousTasks: BelkiTask[],
+    previousDocuments: Map<string, ParsedTaskDocument>
+  ): Promise<void> {
+    const rollbackContents = new Map<string, string>();
+    for (const sourcePath of dedupeStrings(sourcePaths.filter(Boolean))) {
+      const document = previousDocuments.get(sourcePath) || { blocks: [], tasks: [] };
+      const tasks = previousTasks
+        .filter((task) => task.sourcePath === sourcePath)
+        .map((task) => normalizeTaskForSave(task, sourcePath));
+      rollbackContents.set(sourcePath, serializeTaskDocument(document, tasks));
+    }
+
+    try {
+      await this.saveSources(sourcePaths);
+    } catch (error) {
+      await this.rollbackSourceContents(rollbackContents);
+      throw error;
+    }
+  }
+
+  private async rollbackSourceContents(contents: Map<string, string>): Promise<void> {
+    for (const [sourcePath, content] of contents) {
+      const file = await this.ensureFile(sourcePath, "");
+      if (!file) {
+        continue;
+      }
+
+      this.writingPaths.add(normalizePath(sourcePath));
+      try {
+        await this.app.vault.modify(file, content);
+        this.documents.set(sourcePath, parseTaskDocument(content, sourcePath));
+      } catch (rollbackError) {
+        console.warn("[belki] Failed to roll back task source after bulk update failure.", rollbackError);
+      } finally {
+        this.writingPaths.delete(normalizePath(sourcePath));
+      }
+    }
   }
 
   private async writeSources(sourcePaths: string[]): Promise<void> {

--- a/src/views/TaskBoardView.ts
+++ b/src/views/TaskBoardView.ts
@@ -1,4 +1,4 @@
-import { App, ItemView, Modal, Platform, WorkspaceLeaf } from "obsidian";
+import { App, ItemView, Modal, Notice, Platform, WorkspaceLeaf } from "obsidian";
 import {
   ActivityData,
   buildActivityData,
@@ -59,10 +59,12 @@ import { openLabelActionsMenu as openLabelActionsMenuElement } from "./labels/la
 import { renderFiltersAndLabelsView } from "./filters/FiltersAndLabelsView";
 import type { FilterDefinition } from "./filters/FiltersAndLabelsView";
 import { renderTaskActionMenu, renderTaskActions } from "./tasks/taskActions";
+import { renderBulkReschedulePopover } from "./tasks/BulkReschedulePopover";
 import type { CalendarFetchRange } from "../calendar/calendarTypes";
 import { CalendarService } from "../calendar/CalendarService";
 import { collectUpcomingSectionDates } from "../calendar/calendarGrouping";
 import { renderCalendarEventStrip } from "./calendar/CalendarEventStrip";
+import { getVisibleOverdueTasksForBulkReschedule } from "../taskBulkActions";
 
 export const VIEW_TYPE_BELKI = "belki-task-board";
 
@@ -127,6 +129,7 @@ export class TaskBoardView extends ItemView {
   private pendingScrollSnapshot: { top: number; left: number } | null = null;
   private mobileComposerReturnScroll: { top: number; left: number } | null = null;
   private composerCleanup: (() => void) | null = null;
+  private bulkRescheduleCleanup: (() => void) | null = null;
   private renderScheduled = false;
   private calendarRangeRequestKey: string | null = null;
   private handleRootClick = (event: MouseEvent): void => {
@@ -363,6 +366,8 @@ export class TaskBoardView extends ItemView {
   private render(): void {
     this.composerCleanup?.();
     this.composerCleanup = null;
+    this.bulkRescheduleCleanup?.();
+    this.bulkRescheduleCleanup = null;
     this.removeProjectMenu();
     this.removeLabelMenu();
     this.removeTaskActionMenu();
@@ -1026,6 +1031,7 @@ export class TaskBoardView extends ItemView {
       if (hasAnyOverdue) {
         const section = this.createSection(parent, "Overdue", overdue.length, (header) => {
           this.renderOverdueRangeSelect(header);
+          this.renderBulkRescheduleAction(header, overdue);
         });
         this.renderTaskList(section, overdue);
       }
@@ -1623,6 +1629,41 @@ export class TaskBoardView extends ItemView {
         this.renderPreservingMainScroll();
       })();
     });
+  }
+
+  private renderBulkRescheduleAction(parent: HTMLElement, visibleOverdueTasks: BelkiTask[]): void {
+    if (visibleOverdueTasks.length === 0) {
+      return;
+    }
+
+    this.bulkRescheduleCleanup = renderBulkReschedulePopover({
+      parent,
+      count: visibleOverdueTasks.length,
+      onSelectDue: (due, label) => {
+        void this.bulkRescheduleVisibleOverdueTasks(visibleOverdueTasks, due, label);
+      }
+    });
+  }
+
+  private async bulkRescheduleVisibleOverdueTasks(
+    visibleOverdueTasks: BelkiTask[],
+    due: string,
+    label: string
+  ): Promise<void> {
+    const taskIds = visibleOverdueTasks.map((task) => task.id);
+    if (taskIds.length === 0) {
+      this.renderPreservingMainScroll();
+      return;
+    }
+
+    try {
+      await this.store.updateTaskDueDates(taskIds, due);
+      new Notice(`${taskIds.length} task${taskIds.length === 1 ? "" : "s"} rescheduled to ${label}.`);
+      this.renderPreservingMainScroll();
+    } catch (error) {
+      console.warn("[belki] Failed to bulk reschedule overdue tasks.", error);
+      new Notice("belki could not reschedule those tasks. Please try again.");
+    }
   }
 
   private enableTodayDrop(section: HTMLElement): void {
@@ -2304,7 +2345,10 @@ export class TaskBoardView extends ItemView {
   }
 
   private getOverdueTasks(tasks: BelkiTask[]): BelkiTask[] {
-    return tasks.filter((task) => this.isInSelectedOverdueRange(task));
+    return getVisibleOverdueTasksForBulkReschedule(
+      tasks,
+      this.settings.defaultOverdueRange
+    );
   }
 
   private isInSelectedOverdueRange(task: BelkiTask): boolean {

--- a/src/views/datePicker.ts
+++ b/src/views/datePicker.ts
@@ -1,0 +1,114 @@
+import { formatDueDateChip, todayIso } from "../dateUtils";
+
+interface RenderCustomDatePickerOptions {
+  triggerLabel?: string;
+  triggerAriaLabel?: string;
+  triggerRole?: string;
+}
+
+export function renderCustomDatePicker(
+  parent: HTMLElement,
+  currentValue: string | undefined,
+  onSelect: (value: string) => void,
+  options: RenderCustomDatePickerOptions = {}
+): void {
+  const todayStr = todayIso();
+  const initDate = currentValue ? new Date(currentValue + "T00:00:00") : new Date();
+  let viewYear = initDate.getFullYear();
+  let viewMonth = initDate.getMonth();
+
+  const container = parent.createDiv({ cls: "belki-date-custom-wrap" });
+
+  const trigger = container.createEl("button", {
+    cls: "belki-date-preset belki-cal-trigger",
+    attr: {
+      type: "button",
+      ...(options.triggerRole ? { role: options.triggerRole } : {}),
+      ...(options.triggerAriaLabel ? { "aria-label": options.triggerAriaLabel } : {})
+    }
+  });
+  trigger.createSpan({
+    text: currentValue ? formatDueDateChip(currentValue) : options.triggerLabel || "Custom date\u2026"
+  });
+  if (currentValue) trigger.addClass("is-active");
+
+  const calWrap = container.createDiv({ cls: "belki-cal-wrap is-hidden" });
+
+  function renderCal() {
+    calWrap.empty();
+
+    const header = calWrap.createDiv({ cls: "belki-cal-header" });
+    const prevBtn = header.createEl("button", { cls: "belki-cal-nav", attr: { type: "button" } });
+    prevBtn.setText("\u2039");
+    header.createSpan({
+      cls: "belki-cal-title",
+      text: new Date(viewYear, viewMonth, 1)
+        .toLocaleDateString(undefined, { month: "long", year: "numeric" })
+    });
+    const nextBtn = header.createEl("button", { cls: "belki-cal-nav", attr: { type: "button" } });
+    nextBtn.setText("\u203A");
+
+    prevBtn.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      prevBtn.blur();
+      if (--viewMonth < 0) {
+        viewMonth = 11;
+        viewYear--;
+      }
+      renderCal();
+    });
+    nextBtn.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      nextBtn.blur();
+      if (++viewMonth > 11) {
+        viewMonth = 0;
+        viewYear++;
+      }
+      renderCal();
+    });
+
+    const grid = calWrap.createDiv({ cls: "belki-cal-grid" });
+    for (const d of ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]) {
+      grid.createSpan({ cls: "belki-cal-day-hdr", text: d });
+    }
+
+    const firstDow = new Date(viewYear, viewMonth, 1).getDay();
+    const leadingEmpties = firstDow === 0 ? 6 : firstDow - 1;
+    for (let i = 0; i < leadingEmpties; i++) {
+      grid.createDiv({ cls: "belki-cal-day is-empty" });
+    }
+
+    const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+    for (let d = 1; d <= daysInMonth; d++) {
+      const iso = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+      const cell = grid.createEl("button", {
+        cls: "belki-cal-day",
+        text: String(d),
+        attr: { type: "button" }
+      });
+      if (iso === todayStr) cell.addClass("is-today");
+      if (iso === currentValue) cell.addClass("is-selected");
+      cell.addEventListener("click", (e) => {
+        e.stopPropagation();
+        onSelect(iso);
+      });
+    }
+
+    const renderedCells = leadingEmpties + daysInMonth;
+    const trailingEmpties = 42 - renderedCells;
+    for (let i = 0; i < trailingEmpties; i++) {
+      grid.createDiv({ cls: "belki-cal-day is-empty" });
+    }
+  }
+
+  trigger.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const opening = calWrap.hasClass("is-hidden");
+    parent.toggleClass("is-calendar-open", opening);
+    calWrap.toggleClass("is-hidden", !opening);
+    if (opening) renderCal();
+  });
+}

--- a/src/views/task-detail/dateRepeatFields.ts
+++ b/src/views/task-detail/dateRepeatFields.ts
@@ -2,6 +2,7 @@ import { addDaysIso, formatDueDateChip, nextWeekdayIso, todayIso } from "../../d
 import { getRepeatChipLabel, getRepeatLabel, getRepeatPresets, repeatRulesEqual } from "../../repeatUtils";
 import { createBelkiIcon } from "../../ui/components/BelkiIcon";
 import type { RepeatRule } from "../../types";
+import { renderCustomDatePicker } from "../datePicker";
 
 export interface TaskDetailDateRepeatState {
   due?: string;
@@ -99,7 +100,7 @@ function renderDueDatePicker(
 
     popover.createDiv({ cls: "belki-date-divider" });
 
-    renderCustomDatePicker(popover, state.due, "calendar", selectDate);
+    renderCustomDatePicker(popover, state.due, selectDate);
 
     popover.createDiv({ cls: "belki-date-divider" });
     const repeatHeader = popover.createDiv({ cls: "belki-repeat-header" });
@@ -263,7 +264,7 @@ function renderDeadlinePicker(
     addPreset("Next week", addDaysIso(7));
     addPreset("Next weekend", nextWeekdayIso(6));
 
-    renderCustomDatePicker(popover, state.deadline, "deadline", selectDate);
+    renderCustomDatePicker(popover, state.deadline, selectDate);
 
     btn.addEventListener("click", () => {
       const isHidden = popover.hasClass("is-hidden");
@@ -285,99 +286,4 @@ function createField(parent: HTMLElement, label: string): HTMLElement {
   const field = parent.createDiv({ cls: "belki-detail-field" });
   field.createDiv({ cls: "belki-detail-label", text: label });
   return field;
-}
-
-function renderCustomDatePicker(
-  parent: HTMLElement,
-  currentValue: string | undefined,
-  _iconName: string,
-  onSelect: (value: string) => void
-): void {
-  const todayStr = todayIso();
-  const initDate = currentValue ? new Date(currentValue + "T00:00:00") : new Date();
-  let viewYear = initDate.getFullYear();
-  let viewMonth = initDate.getMonth();
-
-  const container = parent.createDiv({ cls: "belki-date-custom-wrap" });
-
-  const trigger = container.createEl("button", {
-    cls: "belki-date-preset belki-cal-trigger",
-    attr: { type: "button" }
-  });
-  trigger.createSpan({ text: currentValue ? formatDueDateChip(currentValue) : "Custom date\u2026" });
-  if (currentValue) trigger.addClass("is-active");
-
-  const calWrap = container.createDiv({ cls: "belki-cal-wrap is-hidden" });
-
-  function renderCal() {
-    calWrap.empty();
-
-    const header = calWrap.createDiv({ cls: "belki-cal-header" });
-    const prevBtn = header.createEl("button", { cls: "belki-cal-nav", attr: { type: "button" } });
-    prevBtn.setText("\u2039");
-    header.createSpan({
-      cls: "belki-cal-title",
-      text: new Date(viewYear, viewMonth, 1)
-        .toLocaleDateString(undefined, { month: "long", year: "numeric" })
-    });
-    const nextBtn = header.createEl("button", { cls: "belki-cal-nav", attr: { type: "button" } });
-    nextBtn.setText("\u203A");
-
-    prevBtn.addEventListener("click", (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      prevBtn.blur();
-      if (--viewMonth < 0) { viewMonth = 11; viewYear--; }
-      renderCal();
-    });
-    nextBtn.addEventListener("click", (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      nextBtn.blur();
-      if (++viewMonth > 11) { viewMonth = 0; viewYear++; }
-      renderCal();
-    });
-
-    const grid = calWrap.createDiv({ cls: "belki-cal-grid" });
-    for (const d of ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]) {
-      grid.createSpan({ cls: "belki-cal-day-hdr", text: d });
-    }
-
-    const firstDow = new Date(viewYear, viewMonth, 1).getDay();
-    const leadingEmpties = firstDow === 0 ? 6 : firstDow - 1;
-    for (let i = 0; i < leadingEmpties; i++) {
-      grid.createDiv({ cls: "belki-cal-day is-empty" });
-    }
-
-    const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
-    for (let d = 1; d <= daysInMonth; d++) {
-      const iso = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
-      const cell = grid.createEl("button", {
-        cls: "belki-cal-day",
-        text: String(d),
-        attr: { type: "button" }
-      });
-      if (iso === todayStr) cell.addClass("is-today");
-      if (iso === currentValue) cell.addClass("is-selected");
-      cell.addEventListener("click", (e) => {
-        e.stopPropagation();
-        onSelect(iso);
-      });
-    }
-
-    const renderedCells = leadingEmpties + daysInMonth;
-    const trailingEmpties = 42 - renderedCells;
-    for (let i = 0; i < trailingEmpties; i++) {
-      grid.createDiv({ cls: "belki-cal-day is-empty" });
-    }
-  }
-
-  trigger.addEventListener("click", (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    const opening = calWrap.hasClass("is-hidden");
-    parent.toggleClass("is-calendar-open", opening);
-    calWrap.toggleClass("is-hidden", !opening);
-    if (opening) renderCal();
-  });
 }

--- a/src/views/tasks/BulkReschedulePopover.ts
+++ b/src/views/tasks/BulkReschedulePopover.ts
@@ -1,0 +1,117 @@
+import { dueDateForBulkRescheduleShortcut } from "../../taskBulkActions";
+import { renderCustomDatePicker } from "../datePicker";
+
+interface RenderBulkReschedulePopoverOptions {
+  parent: HTMLElement;
+  count: number;
+  onSelectDue: (due: string, label: string) => void;
+}
+
+export function renderBulkReschedulePopover(
+  options: RenderBulkReschedulePopoverOptions
+): () => void {
+  const wrapper = options.parent.createDiv({ cls: "belki-bulk-reschedule" });
+  const button = wrapper.createEl("button", {
+    cls: "belki-reschedule",
+    text: `Reschedule ${options.count}`,
+    attr: {
+      type: "button",
+      "aria-haspopup": "menu",
+      "aria-expanded": "false",
+      "aria-label": `Reschedule ${options.count} overdue task${options.count === 1 ? "" : "s"}`
+    }
+  });
+  let popover: HTMLElement | null = null;
+  let detachOutside: (() => void) | null = null;
+
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (popover) {
+      closePopover(true);
+    } else {
+      openPopover();
+    }
+  });
+
+  const openPopover = () => {
+    closePopover(false);
+    button.setAttr("aria-expanded", "true");
+    popover = wrapper.createDiv({
+      cls: "belki-bulk-reschedule-popover",
+      attr: { role: "menu", "aria-label": "Reschedule overdue tasks" }
+    });
+    popover.addEventListener("click", (event) => event.stopPropagation());
+    popover.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        closePopover(true);
+      }
+    });
+
+    popover.createDiv({
+      cls: "belki-bulk-reschedule-title",
+      text: `Reschedule ${options.count} task${options.count === 1 ? "" : "s"}`
+    });
+
+    createPresetButton(popover, "Today", dueDateForBulkRescheduleShortcut("today"), selectDue);
+    createPresetButton(popover, "Tomorrow", dueDateForBulkRescheduleShortcut("tomorrow"), selectDue);
+    createPresetButton(popover, "Next week", dueDateForBulkRescheduleShortcut("nextWeek"), selectDue);
+
+    popover.createDiv({ cls: "belki-date-divider" });
+    renderCustomDatePicker(popover, undefined, (value) => {
+      selectDue(value, value);
+    }, {
+      triggerLabel: "Pick a date...",
+      triggerAriaLabel: "Pick bulk reschedule date",
+      triggerRole: "menuitem"
+    });
+
+    const ownerDocument = wrapper.ownerDocument;
+    const handleOutside = (event: MouseEvent) => {
+      if (!wrapper.contains(event.target as Node)) {
+        closePopover(false);
+      }
+    };
+    ownerDocument.addEventListener("click", handleOutside, { capture: true });
+    detachOutside = () => ownerDocument.removeEventListener("click", handleOutside, { capture: true });
+  };
+
+  const closePopover = (restoreFocus: boolean) => {
+    popover?.remove();
+    popover = null;
+    button.setAttr("aria-expanded", "false");
+    detachOutside?.();
+    detachOutside = null;
+    if (restoreFocus) {
+      button.focus();
+    }
+  };
+
+  const selectDue = (due: string, label: string) => {
+    closePopover(false);
+    options.onSelectDue(due, label);
+  };
+
+  return () => closePopover(false);
+}
+
+function createPresetButton(
+  parent: HTMLElement,
+  label: string,
+  due: string,
+  onSelectDue: (due: string, label: string) => void
+): void {
+  parent
+    .createEl("button", {
+      cls: "belki-bulk-reschedule-option",
+      text: label,
+      attr: { type: "button", role: "menuitem" }
+    })
+    .addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onSelectDue(due, label);
+    });
+}

--- a/styles.css
+++ b/styles.css
@@ -867,18 +867,91 @@ button.belki-sidebar-add-project:active {
   color: var(--belki-text);
 }
 
-.belki-reschedule {
-  background: transparent;
-  border-radius: 6px;
-  color: var(--belki-accent);
-  font-size: 13px;
-  font-weight: 600;
-  margin-left: auto;
-  padding: 5px 8px;
+.belki-bulk-reschedule {
+  flex: 0 0 auto;
+  position: relative;
 }
 
-.belki-reschedule:hover {
+.belki-reschedule {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  box-shadow: none;
+  color: var(--belki-muted);
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 600;
+  height: 28px;
+  justify-content: center;
+  padding: 0 8px;
+  white-space: nowrap;
+}
+
+.belki-reschedule:hover,
+.belki-reschedule:focus-visible,
+.belki-reschedule[aria-expanded="true"] {
   background: var(--belki-hover);
+  color: var(--belki-text);
+}
+
+.belki-reschedule:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--belki-accent) 52%, transparent);
+  outline-offset: 2px;
+}
+
+.belki-bulk-reschedule-popover {
+  background: var(--belki-surface);
+  border: 1px solid var(--belki-border);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.14);
+  display: grid;
+  gap: 2px;
+  min-width: 190px;
+  padding: 6px;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  z-index: 90;
+}
+
+.belki-bulk-reschedule-popover.is-calendar-open {
+  min-width: min(280px, calc(100vw - 28px));
+}
+
+.belki-bulk-reschedule-title {
+  color: var(--belki-muted);
+  font-size: 12px;
+  font-weight: 700;
+  padding: 6px 8px 4px;
+}
+
+.belki-bulk-reschedule-option {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  box-shadow: none;
+  color: var(--belki-text);
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  font-size: 13px;
+  justify-content: space-between;
+  min-height: 32px;
+  padding: 0 8px;
+  text-align: left;
+}
+
+.belki-bulk-reschedule-option:hover,
+.belki-bulk-reschedule-option:focus-visible {
+  background: var(--belki-hover);
+}
+
+.belki-bulk-reschedule-option:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--belki-accent) 52%, transparent);
+  outline-offset: 2px;
 }
 
 .belki-task-list {
@@ -5182,6 +5255,12 @@ button.belki-search-result.is-selected {
 
   .belki-overdue-range-select {
     min-height: 36px;
+  }
+
+  .belki-bulk-reschedule-popover {
+    min-width: min(190px, calc(100vw - 28px));
+    right: 0;
+    top: calc(100% + 6px);
   }
 
   .belki-task-row {

--- a/tests/taskBulkActions.test.ts
+++ b/tests/taskBulkActions.test.ts
@@ -1,0 +1,144 @@
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { addDaysIso, todayIso } from "../src/dateUtils";
+import {
+  createTaskDueDateUpdatePlan,
+  dueDateForBulkRescheduleShortcut,
+  getVisibleOverdueTasksForBulkReschedule,
+  type OverdueRangeDates
+} from "../src/taskBulkActions";
+import type { BelkiTask, RepeatRule } from "../src/types";
+
+const rangeDates: OverdueRangeDates = {
+  today: "2026-07-15",
+  yesterday: "2026-07-14",
+  last7Start: "2026-07-08",
+  last30Start: "2026-06-15"
+};
+
+test("bulk reschedule action is hidden when no visible overdue tasks exist", () => {
+  const tasks = [
+    task("today", { due: "2026-07-15" }),
+    task("future", { due: "2026-07-16" }),
+    task("completed", { due: "2026-07-14", completed: true })
+  ];
+
+  assert.equal(
+    getVisibleOverdueTasksForBulkReschedule(tasks, "yesterday", rangeDates).length,
+    0
+  );
+});
+
+test("bulk reschedule count uses visible overdue tasks only", () => {
+  const tasks = [
+    task("yesterday", { due: "2026-07-14" }),
+    task("last-week", { due: "2026-07-10" }),
+    task("last-month", { due: "2026-06-20" }),
+    task("completed", { due: "2026-07-14", completed: true }),
+    task("subtask", { due: "2026-07-14", parentId: "parent" }),
+    task("today", { due: "2026-07-15" })
+  ];
+
+  assert.deepEqual(
+    getVisibleOverdueTasksForBulkReschedule(tasks, "last7", rangeDates).map((candidate) => candidate.id),
+    ["yesterday", "last-week"]
+  );
+});
+
+test("bulk reschedule respects the selected overdue range", () => {
+  const tasks = [
+    task("yesterday", { due: "2026-07-14" }),
+    task("last-seven", { due: "2026-07-08" }),
+    task("last-thirty", { due: "2026-06-15" }),
+    task("older", { due: "2026-06-14" })
+  ];
+
+  assert.deepEqual(
+    getVisibleOverdueTasksForBulkReschedule(tasks, "yesterday", rangeDates).map((candidate) => candidate.id),
+    ["yesterday"]
+  );
+  assert.deepEqual(
+    getVisibleOverdueTasksForBulkReschedule(tasks, "last7", rangeDates).map((candidate) => candidate.id),
+    ["yesterday", "last-seven"]
+  );
+  assert.deepEqual(
+    getVisibleOverdueTasksForBulkReschedule(tasks, "last30", rangeDates).map((candidate) => candidate.id),
+    ["yesterday", "last-seven", "last-thirty"]
+  );
+  assert.deepEqual(
+    getVisibleOverdueTasksForBulkReschedule(tasks, "older", rangeDates).map((candidate) => candidate.id),
+    ["older"]
+  );
+});
+
+test("bulk reschedule shortcuts use existing local date behavior", () => {
+  assert.equal(dueDateForBulkRescheduleShortcut("today"), todayIso());
+  assert.equal(dueDateForBulkRescheduleShortcut("tomorrow"), addDaysIso(1));
+  assert.equal(dueDateForBulkRescheduleShortcut("nextWeek"), addDaysIso(7));
+});
+
+test("bulk due-date update plan supports custom dates and changes only due fields", () => {
+  const repeat: RepeatRule = {
+    frequency: "weekly",
+    interval: 1,
+    mode: "scheduledDate",
+    weekday: 2,
+    ends: "never"
+  };
+  const original = [
+    task("visible", {
+      due: "2026-07-14",
+      deadline: "2026-07-20",
+      repeat,
+      project: "Work",
+      labels: ["urgent"],
+      attachments: ["_belki_files/Attachments/a/file.png"],
+      description: "Keep me",
+      priority: "P1"
+    }),
+    task("hidden", { due: "2026-07-01", deadline: "2026-07-22" })
+  ];
+
+  const plan = createTaskDueDateUpdatePlan(original, ["visible"], "2026-07-31");
+  const updated = plan.tasks.find((candidate) => candidate.id === "visible");
+  const untouched = plan.tasks.find((candidate) => candidate.id === "hidden");
+
+  assert.deepEqual(plan.changedIds, ["visible"]);
+  assert.equal(updated?.due, "2026-07-31");
+  assert.equal(updated?.deadline, "2026-07-20");
+  assert.deepEqual(updated?.repeat, repeat);
+  assert.equal(updated?.project, "Work");
+  assert.deepEqual(updated?.labels, ["urgent"]);
+  assert.deepEqual(updated?.attachments, ["_belki_files/Attachments/a/file.png"]);
+  assert.equal(updated?.description, "Keep me");
+  assert.equal(updated?.priority, "P1");
+  assert.equal(untouched, original[1]);
+  assert.equal(original[0].due, "2026-07-14");
+});
+
+test("bulk due-date update plan ignores tasks outside the affected id set", () => {
+  const original = [
+    task("visible", { due: "2026-07-14" }),
+    task("calendar-events-are-not-tasks", { due: "2026-07-14" })
+  ];
+  const plan = createTaskDueDateUpdatePlan(original, ["visible"], "2026-07-15");
+
+  assert.equal(plan.tasks[0].due, "2026-07-15");
+  assert.equal(plan.tasks[1], original[1]);
+});
+
+function task(id: string, overrides: Partial<BelkiTask> = {}): BelkiTask {
+  return {
+    id,
+    title: id,
+    completed: false,
+    created: "2026-07-01",
+    priority: "P4",
+    labels: [],
+    attachments: [],
+    extraProperties: [],
+    order: 0,
+    sourcePath: "_belki_files/Data/2026-07.md",
+    ...overrides
+  };
+}


### PR DESCRIPTION
## Summary

Adds bulk rescheduling for the existing Overdue section in Today.

Visible overdue tasks can be rescheduled together to Today, Tomorrow, Next week, or a picked date. The action respects the selected overdue range and only applies to visible top-level overdue tasks.

## Included

- Compact Overdue header Reschedule action
- Anchored popover with Today, Tomorrow, Next week, and shared calendar date picker
- Bulk TaskStore due-date update method
- Single coordinated persistence pass for affected task sources
- Failure rollback for in-memory state and affected source contents where possible
- Shared custom date picker helper reused by Task Detail and bulk rescheduling
- Tests for visible overdue selection, range filtering, shortcuts, custom dates, and metadata preservation

## Not included

- Checkbox-based bulk edit mode
- Changing deadlines or repeat rules
- Updating completed tasks, hidden range tasks, subtasks, or calendar events
- Custom Undo interaction

No matching open issue found for this specific bulk overdue rescheduling feature.

## Checks

- pnpm run typecheck
- pnpm test
- pnpm run build
- git diff --check